### PR TITLE
83 implement stage 5 in dashboard

### DIFF
--- a/dashboard/data/bmg_plate.py
+++ b/dashboard/data/bmg_plate.py
@@ -231,7 +231,7 @@ def calculate_activation_inhibition_zscore(
 
 
 def get_activation_inhibition_zscore_dict(
-    df_stats: pd.DataFrame, plate_values: np.ndarray, modes: list[Mode]
+    df_stats: pd.DataFrame, plate_values: np.ndarray, modes: dict[Mode]
 ) -> dict[str, dict[str, float]]:
     """
     Calculates activation and inhibition for each compound in the plates.

--- a/dashboard/data/combine.py
+++ b/dashboard/data/combine.py
@@ -1,7 +1,9 @@
-import pandas as pd
-import numpy as np
 from functools import reduce
-from dashboard.data.bmg_plate import get_activation_inhibition_zscore_dict, Mode
+
+import numpy as np
+import pandas as pd
+
+from dashboard.data.bmg_plate import Mode, get_activation_inhibition_zscore_dict
 
 
 # NOTE: to be removed
@@ -108,7 +110,7 @@ def combine_bmg_echo_data(
     echo_df: pd.DataFrame,
     df_stats: pd.DataFrame,
     plate_values: np.ndarray,
-    modes: dict[Mode],
+    modes: dict[Mode] = dict(),
     echo_keys: tuple[str] = ("Destination Plate Barcode", "Destination Well"),
 ) -> pd.DataFrame:
     """

--- a/dashboard/data/combine.py
+++ b/dashboard/data/combine.py
@@ -110,7 +110,7 @@ def combine_bmg_echo_data(
     echo_df: pd.DataFrame,
     df_stats: pd.DataFrame,
     plate_values: np.ndarray,
-    modes: dict[Mode] = dict(),
+    modes: dict[Mode],
     echo_keys: tuple[str] = ("Destination Plate Barcode", "Destination Well"),
 ) -> pd.DataFrame:
     """
@@ -123,6 +123,8 @@ def combine_bmg_echo_data(
     :param echo_keys: keys used to merge Echo data with activation and inhibition values #TODO: maybe not necessary and should be hard-coded?
     :return: dataframe with Echo data and activation and inhibition values
     """
+    if modes is None:
+        modes = dict()
     act_inh_dict = get_activation_inhibition_zscore_dict(df_stats, plate_values, modes)
     dfs = []
     for barcode, values_dict in act_inh_dict.items():

--- a/dashboard/data/file_preprocessing/echo_files_parser.py
+++ b/dashboard/data/file_preprocessing/echo_files_parser.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
-import pandas as pd
-import os
+
 import io
+import os
+
+import pandas as pd
 
 
 class EchoFilesParser:
@@ -11,6 +13,8 @@ class EchoFilesParser:
         """
         Parser for csv echo files.
         """
+        self.echo_df = None
+        self.exceptions_df = None
 
     def find_marker_rows(self, file: str, markers: tuple[str]) -> list[int]:
         """
@@ -25,8 +29,6 @@ class EchoFilesParser:
                 markers_rows.append(i)
             if len(markers_rows) == len(markers):
                 return markers_rows
-        if len(markers_rows) == 0:
-            raise ValueError("No marker found in file.")
         return markers_rows
 
     def parse_files(self, echo_files: tuple[str, io.StringIO]) -> EchoFilesParser:

--- a/dashboard/pages/builders.py
+++ b/dashboard/pages/builders.py
@@ -152,7 +152,7 @@ class ProcessPageBuilder(PageBuilder):
             return cant_go_backward, cant_go_forward
 
     @property
-    def elements_raw(self) -> dict[str, str]:
+    def elements(self) -> dict[str, str]:
         """
         Get ids of special elements
 
@@ -164,5 +164,5 @@ class ProcessPageBuilder(PageBuilder):
             "NEXT_BTN": self.next_stage_btn_id,
             "PREV_BTN": self.previous_stage_btn_id,
             "BLOCKER": self.stage_blocker_id,
-            **super().elements_raw,
+            **super().elements,
         }

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -1,14 +1,20 @@
-from dash import html, no_update, callback, Output, Input, State
-
-from ..error import throwable
-from ...data.bmg_plate import parse_bmg_files
-from ...data.file_preprocessing.echo_files_parser import EchoFilesParser
-import io
 import base64
 import functools
+import io
 import uuid
+
 import numpy as np
-import pandas
+import pandas as pd
+import plotly.graph_objects as go
+import pyarrow as pa
+from dash import Input, Output, State, callback, html, no_update
+
+from dashboard.data.bmg_plate import parse_bmg_files
+from dashboard.data.file_preprocessing.echo_files_parser import EchoFilesParser
+from dashboard.storage import FileStorage
+
+from ...data.bmg_plate import parse_bmg_files
+from ...data.file_preprocessing.echo_files_parser import EchoFilesParser
 
 
 def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
@@ -64,9 +70,9 @@ def upload_echo_data(contents, names, last_modified, stored_uuid, file_storage):
 
     if echo_files:
         echo_parser = EchoFilesParser()
-        echo_parser.parse_files(tuple(echo_files))
-        echo_df = echo_parser.echo_df
-        exceptions_df = echo_parser.exceptions_df
+        echo_parser.parse_files(tuple(echo_files)).retain_key_columns()
+        echo_df = echo_parser.get_processed_echo_df()
+        exceptions_df = echo_parser.get_processed_exception_df()
         serialized_processed_df = echo_df.reset_index().to_parquet()
         file_storage.save_file(f"{stored_uuid}_echo_df.pq", serialized_processed_df)
         serialized_processed_exceptions_df = exceptions_df.reset_index().to_parquet()
@@ -81,6 +87,25 @@ def upload_echo_data(contents, names, last_modified, stored_uuid, file_storage):
             html.Ul(children=[html.Li(i) for i in names]),
             html.Hr(),
         ]
+    )
+
+
+# === STAGE 5 ===
+
+
+def on_stage_5_entry(current_stage: int, stored_uuid: str, file_storage: FileStorage):
+    if current_stage != 4:
+        return no_update
+    echo_df = pd.read_parquet(
+        pa.BufferReader(file_storage.read_file(f"{stored_uuid}_echo_df.pq"))
+    )
+    return (
+        html.Div(
+            [
+                html.H5("STAGE 5 ECHO FILES"),
+            ]
+        ),
+        echo_df,
     )
 
 
@@ -102,3 +127,10 @@ def register_callbacks(elements, file_storage):
         Input("upload-echo-data", "last_modified"),
         State("user-uuid", "data"),
     )(functools.partial(upload_echo_data, file_storage=file_storage))
+    (functools.partial(upload_bmg_data, file_storage=file_storage))
+    callback(
+        Output("stage-5", "children"),
+        Output("act-inh-table", "data"),
+        Input(elements["STAGES_STORE"], "data"),
+        State("user-uuid", "data"),
+    )(functools.partial(on_stage_5_entry, file_storage=file_storage))

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -18,9 +18,6 @@ from dashboard.visualization.plots import (
     visualize_multiple_plates,
 )
 
-from ...data.bmg_plate import parse_bmg_files
-from ...data.file_preprocessing.echo_files_parser import EchoFilesParser
-
 # === STAGE 1 ===
 
 

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -1,6 +1,6 @@
+import dash_bootstrap_components as dbc
 from dash import dash_table, dcc, html
 from dash.dash_table.Format import Format, Scheme
-import dash_bootstrap_components as dbc
 
 PRECISION = 5
 _ACT_INH_DATATABLE = dash_table.DataTable(
@@ -28,7 +28,7 @@ _ACT_INH_DATATABLE = dash_table.DataTable(
             format=Format(precision=PRECISION, scheme=Scheme.fixed),
         ),
     ],
-    style_table={"overflowX": "auto"},
+    style_table={"overflowX": "auto", "overflowY": "auto"},
     style_data={
         "padding-left": "10px",
         "padding-right": "10px",
@@ -40,6 +40,16 @@ _ACT_INH_DATATABLE = dash_table.DataTable(
         "font-family": "sans-serif",
         "font-size": "12px",
     },
+    style_header={
+        "backgroundColor": "rgb(230, 230, 230)",
+        "fontWeight": "bold",
+    },
+    style_data_conditional=[
+        {
+            "if": {"row_index": "odd"},
+            "backgroundColor": "rgb(248, 248, 248)",
+        },
+    ],
     filter_action="native",
     filter_options={"case": "insensitive"},
     sort_action="native",
@@ -51,9 +61,14 @@ SUMMARY_STAGE = html.Div(
     id="summary_stage",
     className="container",
     children=[
-        html.H1(
-            children=["Summary"],
-            className="text-center",
+        html.Div(
+            className="mb-2",
+            children=[
+                html.H1(
+                    children=["Summary"],
+                    className="text-center",
+                ),
+            ],
         ),
         dcc.Tabs(
             id="summary-tabs",
@@ -123,11 +138,19 @@ SUMMARY_STAGE = html.Div(
         html.Div(
             className="my-4",
             children=[
-                html.H2(
-                    children=["Compounds Data"],
-                    className="text-center",
+                html.Div(
+                    className="mb-2",
+                    children=[
+                        html.H2(
+                            children=["Compounds Data"],
+                            className="text-center",
+                        ),
+                    ],
                 ),
-                _ACT_INH_DATATABLE,
+                html.Div(
+                    className="overflow-auto mx-2 border border-3 rounded shadow bg-body-tertiary",
+                    children=[_ACT_INH_DATATABLE],
+                ),
             ],
         ),
     ],

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -1,13 +1,47 @@
 from dash import dash_table, dcc, html
+from dash.dash_table.Format import Format, Scheme, Trim
 
+PRECISION = 5
 _ACT_INH_DATATABLE = dash_table.DataTable(
-    id="act-inh-table",
+    id="echo-bmg-combined",
     columns=[
-        {"name": "Destination Plate Barcode", "id": "Destination Plate Barcode"},
-        {"name": "Destination Well", "id": "Destination Well"},
-        {"name": "Volume", "id": "Actual Volume"},
+        dict(id="CMPD ID", name="ID"),
+        dict(id="Destination Plate Barcode", name="Plate Barcode"),
+        dict(id="Destination Well", name="Well"),
+        dict(
+            id="% ACTIVATION",
+            name=" % ACTIVATION",
+            type="numeric",
+            format=Format(precision=PRECISION, scheme=Scheme.fixed),
+        ),
+        dict(
+            id="% INHIBITION",
+            name=" % INHIBITION",
+            type="numeric",
+            format=Format(precision=PRECISION, scheme=Scheme.fixed),
+        ),
+        dict(
+            id="Z-SCORE",
+            name=" Z-SCORE",
+            type="numeric",
+            format=Format(precision=PRECISION, scheme=Scheme.fixed),
+        ),
     ],
+    style_table={"overflowX": "auto"},
+    style_data={
+        "padding-left": "10px",
+        "padding-right": "10px",
+        "width": "70px",
+        "autosize": {"type": "fit", "resize": True},
+        "overflow": "hidden",
+    },
+    filter_action="native",
+    filter_options={"case": "insensitive"},
+    sort_action="native",
+    column_selectable=False,
+    page_size=15,
 )
+
 
 SUMMARY_STAGE = html.Div(
     id="summary_stage",
@@ -17,6 +51,62 @@ SUMMARY_STAGE = html.Div(
             children=["Summary"],
             className="text-center",
         ),
-        html.Div(id="stage-5", children=[_ACT_INH_DATATABLE]),
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[
+                        dcc.Graph(
+                            id="z-score-plot",
+                            figure={},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[
+                        dcc.Graph(
+                            id="activation-plot",
+                            figure={},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col",
+                    children=[
+                        dcc.Graph(
+                            id="inhibition-plot",
+                            figure={},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    className="col my-4",
+                    children=[
+                        html.H2(
+                            children=["Compounds Data"],
+                            className="text-center",
+                        ),
+                        _ACT_INH_DATATABLE,
+                    ],
+                ),
+            ],
+        ),
     ],
 )

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -57,6 +57,26 @@ SUMMARY_STAGE = html.Div(
                 html.Div(
                     className="col",
                     children=[
+                        html.H5("Z-Score range:"),
+                        html.Div(
+                            className="d-flex gap-2 mb-3",
+                            children=[
+                                dcc.Input(
+                                    id="input-z-score-min",
+                                    type="number",
+                                    value=-3,
+                                    className="form-control",
+                                    style={"width": "120px"},
+                                ),
+                                dcc.Input(
+                                    id="input-z-score-max",
+                                    type="number",
+                                    value=3,
+                                    className="form-control",
+                                    style={"width": "120px"},
+                                ),
+                            ],
+                        ),
                         dcc.Graph(
                             id="z-score-plot",
                             figure={},

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -1,4 +1,13 @@
-from dash import html
+from dash import dash_table, dcc, html
+
+_ACT_INH_DATATABLE = dash_table.DataTable(
+    id="act-inh-table",
+    columns=[
+        {"name": "Destination Plate Barcode", "id": "Destination Plate Barcode"},
+        {"name": "Destination Well", "id": "Destination Well"},
+        {"name": "Volume", "id": "Actual Volume"},
+    ],
+)
 
 SUMMARY_STAGE = html.Div(
     id="summary_stage",
@@ -8,5 +17,6 @@ SUMMARY_STAGE = html.Div(
             children=["Summary"],
             className="text-center",
         ),
+        html.Div(id="stage-5", children=[_ACT_INH_DATATABLE]),
     ],
 )

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -1,5 +1,6 @@
 from dash import dash_table, dcc, html
-from dash.dash_table.Format import Format, Scheme, Trim
+from dash.dash_table.Format import Format, Scheme
+import dash_bootstrap_components as dbc
 
 PRECISION = 5
 _ACT_INH_DATATABLE = dash_table.DataTable(
@@ -35,13 +36,16 @@ _ACT_INH_DATATABLE = dash_table.DataTable(
         "autosize": {"type": "fit", "resize": True},
         "overflow": "hidden",
     },
+    style_cell={
+        "font-family": "sans-serif",
+        "font-size": "12px",
+    },
     filter_action="native",
     filter_options={"case": "insensitive"},
     sort_action="native",
     column_selectable=False,
     page_size=15,
 )
-
 
 SUMMARY_STAGE = html.Div(
     id="summary_stage",
@@ -51,45 +55,53 @@ SUMMARY_STAGE = html.Div(
             children=["Summary"],
             className="text-center",
         ),
-        html.Div(
-            className="row",
+        dcc.Tabs(
+            id="summary-tabs",
             children=[
-                html.Div(
-                    className="col",
+                dcc.Tab(
+                    label="Z-Score",
                     children=[
-                        html.H5("Z-Score range:"),
                         html.Div(
-                            className="d-flex gap-2 mb-3",
+                            className="my-4",
                             children=[
-                                dcc.Input(
-                                    id="input-z-score-min",
-                                    type="number",
-                                    value=-3,
-                                    className="form-control",
-                                    style={"width": "120px"},
+                                html.H5("Z-Score range:"),
+                                html.Div(
+                                    className="row",
+                                    children=[
+                                        html.Div(
+                                            className="col mb-4",
+                                            children=[
+                                                dcc.RangeSlider(
+                                                    -10,
+                                                    10,
+                                                    value=[-3, 3],
+                                                    tooltip={
+                                                        "placement": "bottom",
+                                                        "always_visible": True,
+                                                    },
+                                                    id="z-score-slider",
+                                                )
+                                            ],
+                                            style={"width": "750px"},
+                                        ),
+                                        html.Div(
+                                            className="col",
+                                            children=[
+                                                dbc.Button("Apply", id="z-score-button")
+                                            ],
+                                        ),
+                                    ],
                                 ),
-                                dcc.Input(
-                                    id="input-z-score-max",
-                                    type="number",
-                                    value=3,
-                                    className="form-control",
-                                    style={"width": "120px"},
+                                dcc.Graph(
+                                    id="z-score-plot",
+                                    figure={},
                                 ),
                             ],
                         ),
-                        dcc.Graph(
-                            id="z-score-plot",
-                            figure={},
-                        ),
                     ],
                 ),
-            ],
-        ),
-        html.Div(
-            className="row",
-            children=[
-                html.Div(
-                    className="col",
+                dcc.Tab(
+                    label="Activation",
                     children=[
                         dcc.Graph(
                             id="activation-plot",
@@ -97,13 +109,8 @@ SUMMARY_STAGE = html.Div(
                         ),
                     ],
                 ),
-            ],
-        ),
-        html.Div(
-            className="row",
-            children=[
-                html.Div(
-                    className="col",
+                dcc.Tab(
+                    label="Inhibition",
                     children=[
                         dcc.Graph(
                             id="inhibition-plot",
@@ -114,18 +121,13 @@ SUMMARY_STAGE = html.Div(
             ],
         ),
         html.Div(
-            className="row",
+            className="my-4",
             children=[
-                html.Div(
-                    className="col my-4",
-                    children=[
-                        html.H2(
-                            children=["Compounds Data"],
-                            className="text-center",
-                        ),
-                        _ACT_INH_DATATABLE,
-                    ],
+                html.H2(
+                    children=["Compounds Data"],
+                    className="text-center",
                 ),
+                _ACT_INH_DATATABLE,
             ],
         ),
     ],

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -351,13 +351,15 @@ def visualize_activation_inhibition_zscore(
             line_width=3,
             line_dash="dash",
             line_color="gray",
+            annotation_text=f"MIN: {z_score_limits[0]:.2f}",
+            annotation_font_color="gray",
         )
         fig.add_hline(
             y=z_score_limits[1],
             line_width=3,
             line_dash="dash",
             line_color="gray",
-            annotation_text="Z-score limits",
+            annotation_text=f"MAX: {z_score_limits[1]:.2f}",
             annotation_font_color="gray",
         )
 

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -1,12 +1,12 @@
+import string
+from itertools import product
+
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
-from itertools import product
-import string
-
 
 PLOTLY_TEMPLATE = "plotly_white"
 
@@ -272,7 +272,7 @@ def visualize_activation_inhibition_zscore(
     :param z_score_limits: tuple with z-score limits
     :return: plotly figure
     """
-    plate_barcode = compounds_df["Destination Plate Barcode"].unique()[0]
+    # plate_barcode = compounds_df["Destination Plate Barcode"].unique()[0]
     mask = compounds_df["Destination Well"].str[0]
     mask_control_pos = control_pos_df["Destination Well"].str[0]
     mask_control_neg = control_neg_df["Destination Well"].str[0]
@@ -331,7 +331,7 @@ def visualize_activation_inhibition_zscore(
 
     fig.update_layout(
         legend=dict(itemclick=False, itemdoubleclick=False, itemsizing="constant"),
-        title=f"{column} - plate {plate_barcode}",
+        title=f"{column} values of compounds",
         xaxis=dict(title="Row"),
         yaxis=dict(title=column),
         template=PLOTLY_TEMPLATE,

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -301,7 +301,7 @@ def visualize_activation_inhibition_zscore(
             y=compounds_df[column],
             hovertemplate="CMPD ID: TODO<br>Plate: %{text}<br>"
             + column
-            + ": %{y:.2f}<extra></extra>",
+            + ": %{y:.4f}<extra></extra>",
             text=compounds_df["Destination Plate Barcode"],
             mode="markers",
             marker=dict(color="rgb(66, 167, 244)", size=8),
@@ -315,7 +315,7 @@ def visualize_activation_inhibition_zscore(
             y=control_pos_df[column],
             hovertemplate="CMPD ID: TODO<br>Plate: %{text}<br>"
             + column
-            + ": %{y:.2f}<extra></extra>",
+            + ": %{y:.4f}<extra></extra>",
             text=control_pos_df["Destination Plate Barcode"],
             mode="markers",
             marker=dict(color="green", size=10),
@@ -329,7 +329,7 @@ def visualize_activation_inhibition_zscore(
             y=control_neg_df[column],
             hovertemplate="CMPD ID: TODO<br>Plate: %{text}<br>"
             + column
-            + ": %{y:.2f}<extra></extra>",
+            + ": %{y:.4f}<extra></extra>",
             text=control_neg_df["Destination Plate Barcode"],
             mode="markers",
             marker=dict(color="red", size=10),

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -268,7 +268,8 @@ def visualize_activation_inhibition_zscore(
     z_score_limits: tuple = None,
 ) -> go.Figure:
     """
-    Visualize activation/inhibition z-score for each compound
+    Visualize activation/inhibition z-score for each compound.
+
     :param compounds_df: dataframe with compounds
     :param control_pos_df: dataframe with positive controls
     :param control_neg_df: dataframe with negative controls

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ nbformat>=4.2.0
 plotly
 rdkit
 pyarrow
+dash_bootstrap_components


### PR DESCRIPTION
Added stage 5 to the dashboard:
- `% ACTIVITION`/`% INHIBITION`/`Z-SCORE` visualizations 
- interactive Z-score adjustment
- data table with compounds and their key columns

**NOTE: I think we should add one more stage for generating raports etc. (updated last stages visible [here](https://docs.google.com/presentation/d/115voct6UoRCp64WlLkQB6gekUEL3kYhD/edit#slide=id.p12))**

This is what the page looks like for now, the area plot we mentioned during the meeting is TBD
![obraz](https://github.com/zuzg/drug-screening/assets/82370491/42587903-07d1-4f14-9e3f-21ce46f4c205)

Here I used all the data we have from Primary Screening within one assay as an example:
![obraz](https://github.com/zuzg/drug-screening/assets/82370491/4f378605-d546-44f0-a610-ea4e778bd74e)
For the future version of the plot interactivity will be retained only for compounds below/above the thresholds + stats for the area plot will be added (as it gets laggy and interactivity becomes unnecessary)

**NOTE 2: For the plots I tried different layouts on a grid with the data table but ultimately decided it is the most readable like this. However, I'm not an expert when it comes to styling ngl, therefore any suggestions appreciated 🙏🙏**