### PR TITLE
Change view of stage 1 and 4

### DIFF
--- a/dashboard/pages/components.py
+++ b/dashboard/pages/components.py
@@ -90,3 +90,65 @@ def make_page_controls(
             html.Button("Next", id=next_stage_btn_id),
         ]
     )
+
+
+def make_file_list_component(
+    successfull_filenames: list[str], failed_filenames: list[str], num_cols: int
+) -> html.Div:
+    return html.Div(
+        className="row mt-3",
+        children=[
+            html.Div(
+                className="col",
+                children=[
+                    html.H5(
+                        className="text-center",
+                        children=f"Loaded files {len(successfull_filenames)}/{len(successfull_filenames) + len(failed_filenames)}",
+                    ),
+                    html.Hr(),
+                    html.Div(
+                        className="row overflow-auto mh-50",
+                        style={"maxHeight": "200px"},
+                        children=[
+                            html.Div(
+                                className="col",
+                                children=html.Ul(
+                                    children=[
+                                        html.Li(name.split(".")[0])
+                                        for name in successfull_filenames[i::num_cols]
+                                    ]
+                                ),
+                            )
+                            for i in range(num_cols)
+                        ],
+                    ),
+                ],
+            ),
+            html.Div(
+                className="col",
+                children=[
+                    html.H5(
+                        className="text-center",
+                        children=f"Not loaded files {len(failed_filenames)}/{len(successfull_filenames) + len(failed_filenames)}",
+                    ),
+                    html.Hr(),
+                    html.Div(
+                        className="row overflow-auto mh-50",
+                        style={"maxHeight": "200px"},
+                        children=[
+                            html.Div(
+                                className="col",
+                                children=html.Ul(
+                                    children=[
+                                        html.Li(name.split(".")[0])
+                                        for name in failed_filenames[i::num_cols]
+                                    ]
+                                ),
+                            )
+                            for i in range(num_cols)
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -49,9 +49,10 @@ def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
         serialized_processed_df = bmg_df.reset_index().to_parquet()
         file_storage.save_file(f"{stored_uuid}_bmg_df.pq", serialized_processed_df)
 
+    NUM_COLS = 2
     return (
         html.Div(
-            className="row",
+            className="row mt-3",
             children=[
                 html.Div(
                     className="col",
@@ -62,10 +63,20 @@ def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
                         ),
                         html.Hr(),
                         html.Div(
-                            className="col",
-                            children=html.Ul(
-                                children=[html.Li(name) for name in names]
-                            ),
+                            className="row overflow-auto mh-50",
+                            style={"maxHeight": "200px"},
+                            children=[
+                                html.Div(
+                                    className="col",
+                                    children=html.Ul(
+                                        children=[
+                                            html.Li(name.split(".")[0])
+                                            for name in names[i::NUM_COLS]
+                                        ]
+                                    ),
+                                )
+                                for i in range(NUM_COLS)
+                            ],
                         ),
                     ],
                 ),
@@ -74,14 +85,13 @@ def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
                     children=[
                         html.H5(
                             className="text-center",
-                            children=f"Loaded files {val.shape[0]}/{len(names)}",
+                            children=f"Not loaded files {len(names) - val.shape[0]}/{len(names)}",
                         ),
                         html.Hr(),
                         html.Div(
-                            className="col",
-                            children=html.Ul(
-                                children=[html.Li(name) for name in names]
-                            ),
+                            className="row overflow-auto mh-50",
+                            style={"maxHeight": "200px"},
+                            children=[],
                         ),
                     ],
                 ),
@@ -276,23 +286,50 @@ def upload_echo_data(contents, names, last_modified, stored_uuid, file_storage):
             f"{stored_uuid}_exceptions_df.pq", serialized_processed_exceptions_df
         )
 
-    NUM_COLS = 3
+    NUM_COLS = 1
 
     return html.Div(
-        className="row",
+        className="row mt-3",
         children=[
-            html.H5(className="text-center", children="Loaded files"),
-            html.Hr(),
             html.Div(
-                className="row",
+                className="col",
                 children=[
+                    html.H5(
+                        className="text-center",
+                        children=f"Loaded files {len(names)}/{len(names)}",
+                    ),
+                    html.Hr(),
                     html.Div(
-                        className="col",
-                        children=html.Ul(
-                            children=[html.Li(name) for name in names[i::NUM_COLS]]
-                        ),
-                    )
-                    for i in range(NUM_COLS)
+                        className="row overflow-auto mh-50",
+                        style={"maxHeight": "200px"},
+                        children=[
+                            html.Div(
+                                className="col",
+                                children=html.Ul(
+                                    children=[
+                                        html.Li(name.split(".")[0])
+                                        for name in names[i::NUM_COLS]
+                                    ]
+                                ),
+                            )
+                            for i in range(NUM_COLS)
+                        ],
+                    ),
+                ],
+            ),
+            html.Div(
+                className="col",
+                children=[
+                    html.H5(
+                        className="text-center",
+                        children=f"Not loaded files 0/{len(names)}",
+                    ),
+                    html.Hr(),
+                    html.Div(
+                        className="row overflow-auto mh-50",
+                        style={"maxHeight": "200px"},
+                        children=[],
+                    ),
                 ],
             ),
         ],

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -49,23 +49,40 @@ def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
         serialized_processed_df = bmg_df.reset_index().to_parquet()
         file_storage.save_file(f"{stored_uuid}_bmg_df.pq", serialized_processed_df)
 
-    NUM_COLS = 4
     return (
         html.Div(
             className="row",
             children=[
-                html.H5(className="text-center", children="Loaded files"),
-                html.Hr(),
                 html.Div(
-                    className="row",
+                    className="col",
                     children=[
+                        html.H5(
+                            className="text-center",
+                            children=f"Loaded files {val.shape[0]}/{len(names)}",
+                        ),
+                        html.Hr(),
                         html.Div(
                             className="col",
                             children=html.Ul(
-                                children=[html.Li(name) for name in names[i::NUM_COLS]]
+                                children=[html.Li(name) for name in names]
                             ),
-                        )
-                        for i in range(NUM_COLS)
+                        ),
+                    ],
+                ),
+                html.Div(
+                    className="col",
+                    children=[
+                        html.H5(
+                            className="text-center",
+                            children=f"Loaded files {val.shape[0]}/{len(names)}",
+                        ),
+                        html.Hr(),
+                        html.Div(
+                            className="col",
+                            children=html.Ul(
+                                children=[html.Li(name) for name in names]
+                            ),
+                        ),
                     ],
                 ),
             ],

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -20,6 +20,7 @@ from dashboard.visualization.plots import (
     visualize_activation_inhibition_zscore,
     visualize_multiple_plates,
 )
+from dashboard.pages.components import make_file_list_component
 
 # === STAGE 1 ===
 
@@ -49,54 +50,8 @@ def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
         serialized_processed_df = bmg_df.reset_index().to_parquet()
         file_storage.save_file(f"{stored_uuid}_bmg_df.pq", serialized_processed_df)
 
-    NUM_COLS = 2
     return (
-        html.Div(
-            className="row mt-3",
-            children=[
-                html.Div(
-                    className="col",
-                    children=[
-                        html.H5(
-                            className="text-center",
-                            children=f"Loaded files {val.shape[0]}/{len(names)}",
-                        ),
-                        html.Hr(),
-                        html.Div(
-                            className="row overflow-auto mh-50",
-                            style={"maxHeight": "200px"},
-                            children=[
-                                html.Div(
-                                    className="col",
-                                    children=html.Ul(
-                                        children=[
-                                            html.Li(name.split(".")[0])
-                                            for name in names[i::NUM_COLS]
-                                        ]
-                                    ),
-                                )
-                                for i in range(NUM_COLS)
-                            ],
-                        ),
-                    ],
-                ),
-                html.Div(
-                    className="col",
-                    children=[
-                        html.H5(
-                            className="text-center",
-                            children=f"Not loaded files {len(names) - val.shape[0]}/{len(names)}",
-                        ),
-                        html.Hr(),
-                        html.Div(
-                            className="row overflow-auto mh-50",
-                            style={"maxHeight": "200px"},
-                            children=[],
-                        ),
-                    ],
-                ),
-            ],
-        ),
+        make_file_list_component(names, [], 2),
         stored_uuid,
     )
 
@@ -286,54 +241,7 @@ def upload_echo_data(contents, names, last_modified, stored_uuid, file_storage):
             f"{stored_uuid}_exceptions_df.pq", serialized_processed_exceptions_df
         )
 
-    NUM_COLS = 1
-
-    return html.Div(
-        className="row mt-3",
-        children=[
-            html.Div(
-                className="col",
-                children=[
-                    html.H5(
-                        className="text-center",
-                        children=f"Loaded files {len(names)}/{len(names)}",
-                    ),
-                    html.Hr(),
-                    html.Div(
-                        className="row overflow-auto mh-50",
-                        style={"maxHeight": "200px"},
-                        children=[
-                            html.Div(
-                                className="col",
-                                children=html.Ul(
-                                    children=[
-                                        html.Li(name.split(".")[0])
-                                        for name in names[i::NUM_COLS]
-                                    ]
-                                ),
-                            )
-                            for i in range(NUM_COLS)
-                        ],
-                    ),
-                ],
-            ),
-            html.Div(
-                className="col",
-                children=[
-                    html.H5(
-                        className="text-center",
-                        children=f"Not loaded files 0/{len(names)}",
-                    ),
-                    html.Hr(),
-                    html.Div(
-                        className="row overflow-auto mh-50",
-                        style={"maxHeight": "200px"},
-                        children=[],
-                    ),
-                ],
-            ),
-        ],
-    )
+    return make_file_list_component(names, [], 1)
 
 
 # === STAGE 5 ===

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -49,6 +49,7 @@ def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
         serialized_processed_df = bmg_df.reset_index().to_parquet()
         file_storage.save_file(f"{stored_uuid}_bmg_df.pq", serialized_processed_df)
 
+    NUM_COLS = 4
     return (
         html.Div(
             className="row",
@@ -61,27 +62,10 @@ def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
                         html.Div(
                             className="col",
                             children=html.Ul(
-                                children=[html.Li(i) for i in names[0::4]]
+                                children=[html.Li(name) for name in names[i::NUM_COLS]]
                             ),
-                        ),
-                        html.Div(
-                            className="col",
-                            children=html.Ul(
-                                children=[html.Li(i) for i in names[1::4]]
-                            ),
-                        ),
-                        html.Div(
-                            className="col",
-                            children=html.Ul(
-                                children=[html.Li(i) for i in names[2::4]]
-                            ),
-                        ),
-                        html.Div(
-                            className="col",
-                            children=html.Ul(
-                                children=[html.Li(i) for i in names[3::4]]
-                            ),
-                        ),
+                        )
+                        for i in range(NUM_COLS)
                     ],
                 ),
             ],
@@ -275,6 +259,8 @@ def upload_echo_data(contents, names, last_modified, stored_uuid, file_storage):
             f"{stored_uuid}_exceptions_df.pq", serialized_processed_exceptions_df
         )
 
+    NUM_COLS = 3
+
     return html.Div(
         className="row",
         children=[
@@ -285,16 +271,11 @@ def upload_echo_data(contents, names, last_modified, stored_uuid, file_storage):
                 children=[
                     html.Div(
                         className="col",
-                        children=html.Ul(children=[html.Li(i) for i in names[0::3]]),
-                    ),
-                    html.Div(
-                        className="col",
-                        children=html.Ul(children=[html.Li(i) for i in names[1::3]]),
-                    ),
-                    html.Div(
-                        className="col",
-                        children=html.Ul(children=[html.Li(i) for i in names[2::3]]),
-                    ),
+                        children=html.Ul(
+                            children=[html.Li(name) for name in names[i::NUM_COLS]]
+                        ),
+                    )
+                    for i in range(NUM_COLS)
                 ],
             ),
         ],

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -51,12 +51,40 @@ def upload_bmg_data(contents, names, last_modified, stored_uuid, file_storage):
 
     return (
         html.Div(
-            [
-                html.H5("Loaded files"),
+            className="row",
+            children=[
+                html.H5(className="text-center", children="Loaded files"),
                 html.Hr(),
-                html.Ul(children=[html.Li(i) for i in names]),
-                html.Hr(),
-            ]
+                html.Div(
+                    className="row",
+                    children=[
+                        html.Div(
+                            className="col",
+                            children=html.Ul(
+                                children=[html.Li(i) for i in names[0::4]]
+                            ),
+                        ),
+                        html.Div(
+                            className="col",
+                            children=html.Ul(
+                                children=[html.Li(i) for i in names[1::4]]
+                            ),
+                        ),
+                        html.Div(
+                            className="col",
+                            children=html.Ul(
+                                children=[html.Li(i) for i in names[2::4]]
+                            ),
+                        ),
+                        html.Div(
+                            className="col",
+                            children=html.Ul(
+                                children=[html.Li(i) for i in names[3::4]]
+                            ),
+                        ),
+                    ],
+                ),
+            ],
         ),
         stored_uuid,
     )
@@ -248,12 +276,28 @@ def upload_echo_data(contents, names, last_modified, stored_uuid, file_storage):
         )
 
     return html.Div(
-        [
-            html.H5("Loaded files"),
+        className="row",
+        children=[
+            html.H5(className="text-center", children="Loaded files"),
             html.Hr(),
-            html.Ul(children=[html.Li(i) for i in names]),
-            html.Hr(),
-        ]
+            html.Div(
+                className="row",
+                children=[
+                    html.Div(
+                        className="col",
+                        children=html.Ul(children=[html.Li(i) for i in names[0::3]]),
+                    ),
+                    html.Div(
+                        className="col",
+                        children=html.Ul(children=[html.Li(i) for i in names[1::3]]),
+                    ),
+                    html.Div(
+                        className="col",
+                        children=html.Ul(children=[html.Li(i) for i in names[2::3]]),
+                    ),
+                ],
+            ),
+        ],
     )
 
 

--- a/dashboard/pages/primary_screening/stages/s1_bmg_input.py
+++ b/dashboard/pages/primary_screening/stages/s1_bmg_input.py
@@ -1,14 +1,9 @@
 from dash import html, dcc
 
-BMG_DESC = """
-Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-In nec erat eget ante imperdiet tincidunt.
-Aenean facilisis vehicula metus, nec varius elit cursus ac.
-Proin quis viverra lectus. Fusce fermentum ligula mollis vulputate dignissim.
-Cras tempor lacinia tincidunt. Morbi porta tellus tellus, aliquam pharetra massa tincidunt quis.
-Suspendisse vitae diam et erat dapibus placerat ut eget felis.
-Fusce lacinia semper quam, ac lacinia nibh porta vel.
-Cras ullamcorper neque arcu, sit amet vulputate eros feugiat vitae.
+BMG_DESC = """BMG files in ".txt" format should be in the form of two columns,
+where the first column contains the well unique to the plate, e.g. A02, M13, P24, etc.
+The second column is the value for a given compound obtained in a given experiment.
+The name of each file is also the plate identifier.
 """
 
 BMG_INPUT_STAGE = html.Div(

--- a/dashboard/pages/primary_screening/stages/s1_bmg_input.py
+++ b/dashboard/pages/primary_screening/stages/s1_bmg_input.py
@@ -24,6 +24,7 @@ BMG_INPUT_STAGE = html.Div(
                 html.P(BMG_DESC, className="text-justify"),
                 dcc.Upload(
                     id="upload-bmg-data",
+                    accept=".txt",
                     children=html.Div(
                         [
                             "Drag and Drop or ",

--- a/dashboard/pages/primary_screening/stages/s4_echo_input.py
+++ b/dashboard/pages/primary_screening/stages/s4_echo_input.py
@@ -1,5 +1,16 @@
 from dash import html, dcc
 
+ECHO_DESC = """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+In nec erat eget ante imperdiet tincidunt.
+Aenean facilisis vehicula metus, nec varius elit cursus ac.
+Proin quis viverra lectus. Fusce fermentum ligula mollis vulputate dignissim.
+Cras tempor lacinia tincidunt. Morbi porta tellus tellus, aliquam pharetra massa tincidunt quis.
+Suspendisse vitae diam et erat dapibus placerat ut eget felis.
+Fusce lacinia semper quam, ac lacinia nibh porta vel.
+Cras ullamcorper neque arcu, sit amet vulputate eros feugiat vitae.
+"""
+
 ECHO_INPUT_STAGE = html.Div(
     id="echo_input_stage",
     className="container",
@@ -10,8 +21,10 @@ ECHO_INPUT_STAGE = html.Div(
         ),
         html.Div(
             children=[
+                html.P(ECHO_DESC, className="text-justify"),
                 dcc.Upload(
                     id="upload-echo-data",
+                    accept=".csv",
                     children=html.Div(
                         [
                             "Drag and Drop or ",

--- a/dashboard/pages/primary_screening/stages/s4_echo_input.py
+++ b/dashboard/pages/primary_screening/stages/s4_echo_input.py
@@ -1,14 +1,10 @@
 from dash import html, dcc
 
 ECHO_DESC = """
-Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-In nec erat eget ante imperdiet tincidunt.
-Aenean facilisis vehicula metus, nec varius elit cursus ac.
-Proin quis viverra lectus. Fusce fermentum ligula mollis vulputate dignissim.
-Cras tempor lacinia tincidunt. Morbi porta tellus tellus, aliquam pharetra massa tincidunt quis.
-Suspendisse vitae diam et erat dapibus placerat ut eget felis.
-Fusce lacinia semper quam, ac lacinia nibh porta vel.
-Cras ullamcorper neque arcu, sit amet vulputate eros feugiat vitae.
+ECHO files in ".csv" format should have [DETAILS] and (if there are exceptions in the file) [EXCEPTIONS] tags
+in the file. A file without any tags will be treated as containing only exceptions.
+Each row containing information about a compound should contain, among other things,
+the barcode and position on the plate so that it is possible to link ECHO files with BMG files.
 """
 
 ECHO_INPUT_STAGE = html.Div(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,9 @@ PyYAML==6.0
 jenkspy
 numpy
 umap-learn
-dash
+dash>=2.9.0
 dash-bootstrap-components
 nbformat>=4.2.0
 plotly
 rdkit
 pyarrow
-dash_bootstrap_components

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ PyYAML==6.0
 jenkspy
 numpy
 umap-learn
-dash>=2.9.0
+dash
 dash-bootstrap-components
 nbformat>=4.2.0
 plotly


### PR DESCRIPTION
The change mainly concerns visualization. Another change is to limit the possibility of adding files with an inappropriate extension so that instead of informing about the error, it simply prevents it.  
![Zrzut ekranu 2023-05-28 205910](https://github.com/zuzg/drug-screening/assets/101563276/b33926c0-541e-4a6c-9825-7f03296dcfb5)
![Zrzut ekranu 2023-05-28 205811](https://github.com/zuzg/drug-screening/assets/101563276/0f2cbdb4-e710-41ec-8e9f-0869bb59193f)

I left the text field as it looks good and could potentially be used in the future to describe what is happening on this but also on next stages but this is just a suggestion so I look forward to feedback.