### PR TITLE
closes 98 add report stage revamp process controls

### DIFF
--- a/dashboard/assets/script.js
+++ b/dashboard/assets/script.js
@@ -8,3 +8,20 @@ function onPageLoad() {
         }
     });
 }
+
+
+function onStageIndexChange(newIndex) {
+    const points = document.querySelectorAll(".controls__point");
+    points.forEach((point, index) => {
+        if (index === newIndex) {
+            point.classList.add("controls__point--active");
+        } else {
+            point.classList.remove("controls__point--active");
+        }
+        if (index < newIndex) {
+            point.classList.add("controls__point--visited");
+        } else {
+            point.classList.remove("controls__point--visited");
+        }
+    });
+}

--- a/dashboard/assets/style.css
+++ b/dashboard/assets/style.css
@@ -86,8 +86,7 @@
 
 .controls__content {
     position: relative;
-    margin: 3rem 5rem;
-    margin-right: 7rem;
+    margin: 3rem 7rem 2rem 5rem;
     display: flex;
     justify-content: space-evenly;
     flex-grow: 1;

--- a/dashboard/assets/style.css
+++ b/dashboard/assets/style.css
@@ -1,6 +1,8 @@
 :root {
-    --bs-nav-pills-link-active-bg: #f0f;
-    --bs-nav-link-color: #f0f;
+    --controls-line-color: rgb(227, 227, 227);
+    --controls-dot-default: rgb(255, 255, 255);
+    --controls-dot-active: var(--bs-primary);
+    --controls-dot-visited: rgb(0, 0, 0);
 }
 
 .content {
@@ -70,4 +72,75 @@
 
 .fixed-width-150 {
     width: 150px;
+}
+
+
+.controls {
+    padding: 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-direction: row;
+    width: 100%;
+}
+
+.controls__content {
+    position: relative;
+    margin: 3rem 5rem;
+    margin-right: 7rem;
+    display: flex;
+    justify-content: space-evenly;
+    flex-grow: 1;
+    align-items: center;
+    flex-direction: row;
+    list-style: none;
+}
+
+.controls__content::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 100%;
+    height: 4px;
+    background-color: var(--controls-line-color);
+    transform: translateY(-2px);
+}
+
+.controls__point {
+    position: relative;
+    padding-left: 1rem;
+}
+
+.controls__point::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--controls-dot-default);
+    border: 4px solid var(--controls-line-color);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    transition: all 0.2s ease-in-out,
+        background-color 0.2s ease-in-out;
+}
+
+.controls__point--active::after {
+    background-color: var(--controls-dot-active);
+    transform: scale(1.25) translate(-50%, -40%);
+}
+
+.controls__point--visited::after {
+    background-color: var(--controls-dot-visited);
+}
+
+.controls__point__label {
+    position: absolute;
+    left: 0.7rem;
+    top: -2.75rem;
+    font-weight: 700;
+    font-size: 0.9rem;
+    width: 120px;
+    transform: rotate(-20deg);
 }

--- a/dashboard/assets/style.css
+++ b/dashboard/assets/style.css
@@ -144,3 +144,14 @@
     width: 120px;
     transform: rotate(-20deg);
 }
+
+
+.btn--round {
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/dashboard/pages/builders.py
+++ b/dashboard/pages/builders.py
@@ -79,7 +79,7 @@ class ProcessPageBuilder(PageBuilder):
                 dash.html.Div(
                     children=[],
                     id=self.stages_container_id,
-                    className="flex-grow-1 w-100",
+                    className="flex-grow-1 w-100 mt-4",
                 ),
             ]
         )

--- a/dashboard/pages/builders.py
+++ b/dashboard/pages/builders.py
@@ -1,6 +1,6 @@
 import dash
 
-from .components import make_page_controls
+from .components import make_page_controls_rich_widget
 
 
 class PageBuilder:
@@ -80,10 +80,10 @@ class ProcessPageBuilder(PageBuilder):
                     id=self.stages_container_id,
                     className="flex-grow-1 w-100",
                 ),
-                make_page_controls(
-                    previous_stage_btn_id=self.previous_stage_btn_id,
-                    next_stage_btn_id=self.next_stage_btn_id,
-                ),
+                # make_page_controls(
+                #     previous_stage_btn_id=self.previous_stage_btn_id,
+                #     next_stage_btn_id=self.next_stage_btn_id,
+                # ),
             ]
         )
 
@@ -152,6 +152,22 @@ class ProcessPageBuilder(PageBuilder):
             cant_go_backward = current_stage <= 0
             cant_go_forward = (current_stage >= len(self.stages) - 1) or blocker
             return cant_go_backward, cant_go_forward
+
+    def build(self) -> dash.html.Div:
+        """
+        Build the page layout and register callbacks
+
+        :return: built page layout
+        """
+        self.layout.children.insert(
+            0,
+            make_page_controls_rich_widget(
+                previous_stage_btn_id=self.previous_stage_btn_id,
+                next_stage_btn_id=self.next_stage_btn_id,
+                stages_count=len(self.stages),
+            ),
+        )
+        return super().build()
 
     @property
     def elements(self) -> dict[str, str]:

--- a/dashboard/pages/components.py
+++ b/dashboard/pages/components.py
@@ -100,7 +100,7 @@ def make_page_controls_rich_widget(
     )
 
     return html.Div(
-        className="controls",
+        className="controls border-bottom",
         children=[
             html.Button(
                 id=previous_stage_btn_id,

--- a/dashboard/pages/components.py
+++ b/dashboard/pages/components.py
@@ -93,15 +93,39 @@ def make_page_controls(
 
 
 def make_page_controls_rich_widget(
-    previous_stage_btn_id: str,
-    next_stage_btn_id: str,
-    stages_count: int,
+    previous_stage_btn_id: str, next_stage_btn_id: str, stage_names: list[str]
 ) -> html.Div:
-    return html.Div(
+    controls_content = html.Ul(
+        className="controls__content",
         children=[
-            html.Button("Previous", id=previous_stage_btn_id),
-            html.Button("Next", id=next_stage_btn_id),
-        ]
+            html.Li(
+                className="controls__point",
+                children=[
+                    html.Span(
+                        className="controls__point__label",
+                        children=stage_name,
+                    ),
+                ],
+            )
+            for stage_name in stage_names
+        ],
+    )
+
+    return html.Div(
+        className="controls",
+        children=[
+            html.Button(
+                "Previous",
+                id=previous_stage_btn_id,
+                className="btn btn-primary fixed-width-100",
+            ),
+            controls_content,
+            html.Button(
+                "Next",
+                id=next_stage_btn_id,
+                className="btn btn-primary fixed-width-100",
+            ),
+        ],
     )
 
 

--- a/dashboard/pages/components.py
+++ b/dashboard/pages/components.py
@@ -103,15 +103,19 @@ def make_page_controls_rich_widget(
         className="controls",
         children=[
             html.Button(
-                "Previous",
                 id=previous_stage_btn_id,
-                className="btn btn-primary fixed-width-100",
+                className="btn btn-primary btn--round",
+                children=[
+                    html.I(className="fa-solid fa-arrow-left"),
+                ],
             ),
             controls_content,
             html.Button(
-                "Next",
                 id=next_stage_btn_id,
-                className="btn btn-primary fixed-width-100",
+                className="btn btn-primary btn--round",
+                children=[
+                    html.I(className="fa-solid fa-arrow-right"),
+                ],
             ),
         ],
     )

--- a/dashboard/pages/components.py
+++ b/dashboard/pages/components.py
@@ -5,6 +5,20 @@ Contains common elements for the pages.
 from dash import html, dcc
 
 
+# Extra elements that are not part of the main layout
+# Invisible or detached from the main layout
+# Common for all pages
+EXTRA = html.Div(
+    id="extra",
+    children=[
+        html.Div(id="error-box", style={"color": "red"}),
+        dcc.Store(id="error-msg", data=""),
+        html.Div(id="dummy"),
+        dcc.Store(id="user-uuid", storage_type="local"),
+    ],
+)
+
+
 def make_main_header(page_registry: dict):
     nav_bar = html.Ul(
         children=[
@@ -63,32 +77,6 @@ def make_footer(version: str) -> html.Footer:
                 ),
             )
         ],
-    )
-
-
-# Extra elements that are not part of the main layout
-# Invisible or detached from the main layout
-# Common for all pages
-EXTRA = html.Div(
-    id="extra",
-    children=[
-        html.Div(id="error-box", style={"color": "red"}),
-        dcc.Store(id="error-msg", data=""),
-        html.Div(id="dummy"),
-        dcc.Store(id="user-uuid", storage_type="local"),
-    ],
-)
-
-
-def make_page_controls(
-    previous_stage_btn_id: str,
-    next_stage_btn_id: str,
-) -> html.Div:
-    return html.Div(
-        children=[
-            html.Button("Previous", id=previous_stage_btn_id),
-            html.Button("Next", id=next_stage_btn_id),
-        ]
     )
 
 

--- a/dashboard/pages/components.py
+++ b/dashboard/pages/components.py
@@ -92,6 +92,19 @@ def make_page_controls(
     )
 
 
+def make_page_controls_rich_widget(
+    previous_stage_btn_id: str,
+    next_stage_btn_id: str,
+    stages_count: int,
+) -> html.Div:
+    return html.Div(
+        children=[
+            html.Button("Previous", id=previous_stage_btn_id),
+            html.Button("Next", id=next_stage_btn_id),
+        ]
+    )
+
+
 def make_file_list_component(
     successfull_filenames: list[str], failed_filenames: list[str], num_cols: int
 ) -> html.Div:

--- a/dashboard/pages/primary_screening/page.py
+++ b/dashboard/pages/primary_screening/page.py
@@ -11,7 +11,15 @@ NAME = "Primary Screening"
 register_page(path="/primary-screening", name=NAME, module=__name__)
 
 pb = ProcessPageBuilder(name=NAME)
-pb.add_stages(STAGES)
+STAGE_NAMES = [
+    "BMG Input",
+    "Outliers Preview",
+    "Statistics",
+    "Echo Input",
+    "Summary",
+    "Report",
+]
+pb.add_stages(STAGES, STAGE_NAMES)
 layout = pb.build()
 
 file_storage = LocalFileStorage()

--- a/dashboard/pages/primary_screening/stages/__init__.py
+++ b/dashboard/pages/primary_screening/stages/__init__.py
@@ -3,6 +3,7 @@ from .s2_outliers_purging import OUTLIERS_PURGING_STAGE
 from .s3_filtered_plates_stats import FILTERED_PLATES_STATS_STAGE
 from .s4_echo_input import ECHO_INPUT_STAGE
 from .s5_summary import SUMMARY_STAGE
+from .s6_report import REPORT_STAGE
 
 STAGES = [
     BMG_INPUT_STAGE,
@@ -10,4 +11,5 @@ STAGES = [
     FILTERED_PLATES_STATS_STAGE,
     ECHO_INPUT_STAGE,
     SUMMARY_STAGE,
+    REPORT_STAGE,
 ]

--- a/dashboard/pages/primary_screening/stages/s1_bmg_input.py
+++ b/dashboard/pages/primary_screening/stages/s1_bmg_input.py
@@ -10,10 +10,6 @@ BMG_INPUT_STAGE = html.Div(
     id="bmg_input_stage",
     className="container",
     children=[
-        html.H1(
-            children=["BMG Input"],
-            className="text-center",
-        ),
         html.Div(
             children=[
                 html.P(BMG_DESC, className="text-justify"),

--- a/dashboard/pages/primary_screening/stages/s2_outliers_purging.py
+++ b/dashboard/pages/primary_screening/stages/s2_outliers_purging.py
@@ -179,7 +179,7 @@ OUTLIERS_PURGING_STAGE = html.Div(
     className="container h-100 d-flex flex-column",
     children=[
         html.Div(
-            className="row mb-2 pb-2 border-bottom",
+            className="row mb-2 pb-2",
             children=[
                 STATS_SECTION,
             ],

--- a/dashboard/pages/primary_screening/stages/s2_outliers_purging.py
+++ b/dashboard/pages/primary_screening/stages/s2_outliers_purging.py
@@ -5,7 +5,6 @@ _COMPOUNDS_DATATABLE = dash_table.DataTable(
     style_table={
         "overflowX": "auto",
         "overflowY": "auto",
-        # "height": "100%",
     },
     style_cell={
         "textAlign": "right",
@@ -179,10 +178,6 @@ OUTLIERS_PURGING_STAGE = html.Div(
     id="outliers_purging_stage",
     className="container h-100 d-flex flex-column",
     children=[
-        html.H1(
-            children=["Outliers Purging"],
-            className="text-center",
-        ),
         html.Div(
             className="row mb-2 pb-2 border-bottom",
             children=[

--- a/dashboard/pages/primary_screening/stages/s3_filtered_plates_stats.py
+++ b/dashboard/pages/primary_screening/stages/s3_filtered_plates_stats.py
@@ -5,10 +5,6 @@ FILTERED_PLATES_STATS_STAGE = html.Div(
     id="filtered_plates_stats_stage",
     className="container",
     children=[
-        html.H1(
-            children=["Plates Statistics"],
-            className="text-center",
-        ),
         html.Div(
             className="row",
             children=[

--- a/dashboard/pages/primary_screening/stages/s4_echo_input.py
+++ b/dashboard/pages/primary_screening/stages/s4_echo_input.py
@@ -11,10 +11,6 @@ ECHO_INPUT_STAGE = html.Div(
     id="echo_input_stage",
     className="container",
     children=[
-        html.H1(
-            children=["ECHO Input"],
-            className="text-center",
-        ),
         html.Div(
             children=[
                 html.P(ECHO_DESC, className="text-justify"),

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -61,15 +61,15 @@ SUMMARY_STAGE = html.Div(
     id="summary_stage",
     className="container",
     children=[
-        html.Div(
-            className="mb-2",
-            children=[
-                html.H1(
-                    children=["Summary"],
-                    className="text-center",
-                ),
-            ],
-        ),
+        # html.Div(
+        #     className="mb-2",
+        #     children=[
+        #         html.H1(
+        #             children=["Summary"],
+        #             className="text-center",
+        #         ),
+        #     ],
+        # ),
         dcc.Tabs(
             id="summary-tabs",
             children=[

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -61,15 +61,6 @@ SUMMARY_STAGE = html.Div(
     id="summary_stage",
     className="container",
     children=[
-        # html.Div(
-        #     className="mb-2",
-        #     children=[
-        #         html.H1(
-        #             children=["Summary"],
-        #             className="text-center",
-        #         ),
-        #     ],
-        # ),
         dcc.Tabs(
             id="summary-tabs",
             children=[

--- a/dashboard/pages/primary_screening/stages/s6_report.py
+++ b/dashboard/pages/primary_screening/stages/s6_report.py
@@ -1,0 +1,22 @@
+from dash import html
+
+REPORT_STAGE = html.Div(
+    id="report_stage",
+    className="container",
+    children=[
+        html.H1(
+            children=["Report"],
+            className="text-center",
+        ),
+        html.Div(
+            className="my-4",
+            children=[
+                html.Button(
+                    "Generate Report",
+                    className="btn btn-primary btn-lg btn-block",
+                    id="generate-report-button",
+                ),
+            ],
+        ),
+    ],
+)

--- a/dashboard/pages/primary_screening/stages/s6_report.py
+++ b/dashboard/pages/primary_screening/stages/s6_report.py
@@ -4,10 +4,6 @@ REPORT_STAGE = html.Div(
     id="report_stage",
     className="container",
     children=[
-        html.H1(
-            children=["Report"],
-            className="text-center",
-        ),
         html.Div(
             className="my-4",
             children=[


### PR DESCRIPTION
Improved UI for traversing our processes.

The new controls widget generalizes well and can handle varying number of stages - so that we can use it for all future processes besides Primary Screening.

As the titles are visible on the controls widget and the current stage is indicated visually, I removed titles from all stages.

Here is how it looks like:

![image](https://github.com/zuzg/drug-screening/assets/72276326/25c6fd10-6a87-4e8a-ad06-27079e101423)
![image](https://github.com/zuzg/drug-screening/assets/72276326/67c9b32a-b856-4350-a8f1-f6c32d7654e1)

Any stylistic suggestions are welcome 🥸

As a bonus - I added a report-stage placeholder:
![image](https://github.com/zuzg/drug-screening/assets/72276326/7fcdc65e-138b-4c91-88b8-900b7c33b3f6)
