### PR TITLE
Update Z-score plot

### DIFF
--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -274,18 +274,24 @@ def on_summary_entry(current_stage: int, stored_uuid: str, file_storage: FileSto
         echo_bmg_combined.drop_duplicates()
     )  # TODO: inform the user about it/allow for deciding what to do
 
+    print(echo_bmg_combined.head())
     echo_bmg_combined = echo_bmg_combined.reset_index().to_dict("records")
 
+    # NOTE: check the range of the z-score that's needed
     min_z, max_z = compounds_df["Z-SCORE"].min(), compounds_df["Z-SCORE"].max()
     marks = {i: "{}".format(i) for i in range(0, ceil(max_z), 5)}
     if floor(min_z) < 0:
         marks.update({i: "{}".format(i) for i in range(floor(min_z), 0, 5)})
 
     # NOTE: here I only added the position that is required for the plot_zscore function
-    fig_z_score, new_echo_df = plot_zscore(compounds_df, control_pos_df, control_neg_df)
-
-    serialized_new_echo_df = new_echo_df.reset_index().to_parquet()
-    file_storage.save_file(f"{stored_uuid}_echo_df.pq", serialized_new_echo_df)
+    if "id_pos" not in compounds_df.columns:
+        fig_z_score, new_echo_df = plot_zscore(
+            compounds_df, control_pos_df, control_neg_df
+        )
+        serialized_new_echo_df = new_echo_df.reset_index().to_parquet()
+        file_storage.save_file(f"{stored_uuid}_echo_df.pq", serialized_new_echo_df)
+    else:
+        fig_z_score, _ = plot_zscore(compounds_df, control_pos_df, control_neg_df)
 
     z_score_slider = dcc.RangeSlider(
         floor(min_z),
@@ -330,7 +336,7 @@ def on_z_score_range_update(value, figure):
             "y0": min_value,
             "y1": min_value,
             "line": {
-                "color": "gray",
+                "color": "red",
                 "width": 3,
                 "dash": "dash",
             },
@@ -343,7 +349,7 @@ def on_z_score_range_update(value, figure):
             "y0": max_value,
             "y1": max_value,
             "line": {
-                "color": "gray",
+                "color": "red",
                 "width": 3,
                 "dash": "dash",
             },
@@ -355,18 +361,18 @@ def on_z_score_range_update(value, figure):
             "y": min_value,
             "text": f"MIN: {min_value:.2f}",
             "showarrow": False,
-            "font": {"color": "gray"},
+            "font": {"color": "red"},
         }
     )
 
     annotations.append(
         {
-            "x": 1,
-            "xanchor": "right",
+            # "x": 10,
+            # "xanchor": "right",
             "y": max_value,
             "text": f"MAX: {max_value:.2f}",
             "showarrow": False,
-            "font": {"color": "gray"},
+            "font": {"color": "red"},
         }
     )
 

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -12,6 +12,7 @@ from dash import Input, Output, State, callback, callback_context, html, no_upda
 from dashboard.data.bmg_plate import filter_low_quality_plates, parse_bmg_files
 from dashboard.data.combine import combine_bmg_echo_data, split_compounds_controls
 from dashboard.data.file_preprocessing.echo_files_parser import EchoFilesParser
+from dashboard.pages.components import make_file_list_component
 from dashboard.storage import FileStorage
 from dashboard.visualization.plots import (
     plot_control_values,
@@ -20,7 +21,7 @@ from dashboard.visualization.plots import (
     visualize_activation_inhibition_zscore,
     visualize_multiple_plates,
 )
-from dashboard.pages.components import make_file_list_component
+from dashboard.visualization.z_score_plot import plot_zscore
 
 # === STAGE 1 ===
 
@@ -273,9 +274,7 @@ def on_summary_entry(current_stage: int, stored_uuid: str, file_storage: FileSto
 
     echo_bmg_combined = echo_bmg_combined.reset_index().to_dict("records")
 
-    fig_z_score = visualize_activation_inhibition_zscore(
-        compounds_df, control_pos_df, control_neg_df, "Z-SCORE", (-3, 3)
-    )
+    fig_z_score = plot_zscore(compounds_df, control_pos_df, control_neg_df, (-3, 3))
 
     fig_activation = visualize_activation_inhibition_zscore(
         compounds_df, control_pos_df, control_neg_df, "% ACTIVATION"

--- a/dashboard/pages/primary_screening/callbacks.py
+++ b/dashboard/pages/primary_screening/callbacks.py
@@ -371,7 +371,7 @@ def on_z_score_range_update(value, figure):
     )
 
     new_figure.update_layout(shapes=shapes, annotations=annotations)
-    return new_figure
+    return new_figure, False
 
 
 def on_z_score_button_click(
@@ -473,7 +473,7 @@ def register_callbacks(elements, file_storage):
     )(functools.partial(on_summary_entry, file_storage=file_storage))
     callback(
         Output("z-score-plot", "figure", allow_duplicate=True),
-        # Input("z-score-button", "n_clicks"),
+        Output("z-score-button", "disabled"),
         Input("z-score-slider", "value"),
         State("z-score-plot", "figure"),
         prevent_initial_call=True,

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -91,7 +91,11 @@ SUMMARY_STAGE = html.Div(
                                         html.Div(
                                             className="col",
                                             children=[
-                                                dbc.Button("Apply", id="z-score-button")
+                                                dbc.Button(
+                                                    "Apply",
+                                                    id="z-score-button",
+                                                    disabled=True,
+                                                )
                                             ],
                                         ),
                                     ],

--- a/dashboard/pages/primary_screening/stages/s5_summary.py
+++ b/dashboard/pages/primary_screening/stages/s5_summary.py
@@ -85,18 +85,7 @@ SUMMARY_STAGE = html.Div(
                                     children=[
                                         html.Div(
                                             className="col mb-4",
-                                            children=[
-                                                dcc.RangeSlider(
-                                                    -10,
-                                                    10,
-                                                    value=[-3, 3],
-                                                    tooltip={
-                                                        "placement": "bottom",
-                                                        "always_visible": True,
-                                                    },
-                                                    id="z-score-slider",
-                                                )
-                                            ],
+                                            id="z-score-slider",
                                             style={"width": "750px"},
                                         ),
                                         html.Div(

--- a/dashboard/visualization/z_score_plot.py
+++ b/dashboard/visualization/z_score_plot.py
@@ -14,7 +14,7 @@ def prepare_data_plot(df, well, col, id_pos="id_pos", range_max=None):
     else:
         df["lb"] = df["mean"] - df["std"]
         df["ub"] = df["mean"] + df["std"]
-    df = df.sort_values("mean")
+    df = df.sort_values("std")  # can be "mean" as well
 
     if range_max is not None:
         x_positions = [0]
@@ -25,7 +25,6 @@ def prepare_data_plot(df, well, col, id_pos="id_pos", range_max=None):
             i += frac
         df[id_pos] = x_positions
     else:
-        #     df[id_pos] = range(0, no_items, no_items/len(df))
         df[id_pos] = range(len(df))
 
     return df
@@ -149,7 +148,6 @@ def plot_zscore(
     fig.update_xaxes(showticklabels=False)
     fig.update_layout(
         title=f"Z-score plot",
-        # xaxis_title="Well",
         xaxis=dict(
             {
                 "title": "Well",

--- a/dashboard/visualization/z_score_plot.py
+++ b/dashboard/visualization/z_score_plot.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pandas as pd
+import plotly.graph_objs as go
+
+PLOTLY_TEMPLATE = "plotly_white"
+
+
+def prepare_data_plot(df, well, col):
+    df = df.groupby(well)[col].agg(["mean", "std"]).reset_index()
+    df["lb"] = df["mean"] - df["std"]
+    df["ub"] = df["mean"] + df["std"]
+
+    # Add 'pos' column -> pos = position (eg. B01 = 1*24+1)
+    df["pos"] = df[well].apply(lambda x: (ord(x[0]) - ord("A")) * 24 + int(x[1:]))
+    df = df.sort_values("pos")
+
+    return df
+
+
+def plot_zscore(
+    compounds_df: pd.DataFrame,
+    control_pos_df: pd.DataFrame,
+    control_neg_df: pd.DataFrame,
+    z_score_limits: tuple = None,
+) -> go.Figure:
+    WELL = "Destination Well"
+    Z_SCORE = "Z-SCORE"
+    fig = go.Figure()
+
+    compounds_df = prepare_data_plot(compounds_df, WELL, Z_SCORE)
+    control_pos_df = prepare_data_plot(control_pos_df, WELL, Z_SCORE)
+    control_neg_df = prepare_data_plot(control_neg_df, WELL, Z_SCORE)
+
+    # to be updated
+    dfs = [compounds_df, control_pos_df, control_neg_df]
+    colors = ["rgb(66,167,244)", "rgb(0,255,0)", "rgb(255,0,0)"]
+    colors_shade = ["rgba(66,167,244,0.4)", "rgba(0,255,0,0.2)", "rgba(255,0,0,0.2)"]
+    names = ["COMPOUNDS", "CONTROL POS", "CONTROL NEG"]
+
+    for i, df in enumerate(dfs):
+        fig.add_trace(
+            go.Scatter(
+                x=df["pos"],
+                y=df["mean"],
+                line=dict(color=colors[i]),
+                mode="lines",
+                name=names[i],
+                legendgroup=names[i],
+                hovertemplate=f"{WELL}: %{{x}}<br>z-score: %{{y:.2f}}<extra></extra>",  # TO IMPROVE
+            )
+        )
+
+        fig.add_trace(
+            go.Scatter(
+                x=pd.concat(
+                    [df["pos"], df["pos"][::-1]], ignore_index=True
+                ),  # well, then well reversed
+                y=pd.concat(
+                    [df["ub"], df["lb"][::-1]], ignore_index=True
+                ),  # upper, then lower reversed
+                fill="toself",
+                fillcolor=colors_shade[i],
+                line=dict(color="rgba(255,255,255,0)"),
+                hoverinfo="skip",
+                showlegend=False,
+                name="Shaded Area",
+                legendgroup=names[i],
+            )
+        )
+
+    fig.update_xaxes(showticklabels=False)
+    fig.update_layout(
+        title=f"Z-score plot",
+        xaxis_title="Well",
+        yaxis_title="z-score",
+        margin=dict(t=50, b=30, l=30, r=30),
+        template=PLOTLY_TEMPLATE,
+    )
+
+    if z_score_limits is not None:
+        fig.add_hline(
+            y=z_score_limits[0],
+            line_width=3,
+            line_dash="dash",
+            line_color="gray",
+            annotation_text=f"MIN: {z_score_limits[0]:.2f}",
+            annotation_font_color="gray",
+        )
+        fig.add_hline(
+            y=z_score_limits[1],
+            line_width=3,
+            line_dash="dash",
+            line_color="gray",
+            annotation_text=f"MAX: {z_score_limits[1]:.2f}",
+            annotation_font_color="gray",
+        )
+
+    return fig

--- a/dashboard/visualization/z_score_plot.py
+++ b/dashboard/visualization/z_score_plot.py
@@ -5,14 +5,28 @@ import plotly.graph_objs as go
 PLOTLY_TEMPLATE = "plotly_white"
 
 
-def prepare_data_plot(df, well, col):
+def prepare_data_plot(df, well, col, id_pos="index", range_max=None):
     df = df.groupby(well)[col].agg(["mean", "std"]).reset_index()
-    df["lb"] = df["mean"] - df["std"]
-    df["ub"] = df["mean"] + df["std"]
+    if df["std"].isna().any():
+        df["std"] = 0.0
+        df["lb"] = df["mean"]
+        df["ub"] = df["mean"]
+    else:
+        df["lb"] = df["mean"] - df["std"]
+        df["ub"] = df["mean"] + df["std"]
+    df = df.sort_values("mean")
 
-    # Add 'pos' column -> pos = position (eg. B01 = 1*24+1)
-    df["pos"] = df[well].apply(lambda x: (ord(x[0]) - ord("A")) * 24 + int(x[1:]))
-    df = df.sort_values("pos")
+    if range_max is not None:
+        x_positions = [0]
+        frac = range_max / len(df)
+        i = frac
+        while i < range_max:
+            x_positions.append(i)
+            i += frac
+        df[id_pos] = x_positions
+    else:
+        #     df[id_pos] = range(0, no_items, no_items/len(df))
+        df[id_pos] = range(len(df))
 
     return df
 
@@ -23,37 +37,56 @@ def plot_zscore(
     control_neg_df: pd.DataFrame,
     z_score_limits: tuple = None,
 ) -> go.Figure:
+    id_pos = "index"
+    PLATE = "Destination Plate Barcode"
     WELL = "Destination Well"
     Z_SCORE = "Z-SCORE"
     fig = go.Figure()
 
-    compounds_df = prepare_data_plot(compounds_df, WELL, Z_SCORE)
-    control_pos_df = prepare_data_plot(control_pos_df, WELL, Z_SCORE)
-    control_neg_df = prepare_data_plot(control_neg_df, WELL, Z_SCORE)
+    if z_score_limits:
+        mask = (compounds_df[Z_SCORE] >= z_score_limits[0]) & (
+            compounds_df[Z_SCORE] <= z_score_limits[1]
+        )
+        compounds_outside_df = compounds_df[~mask].copy()
+
+    else:
+        z_score_limits = compounds_df[Z_SCORE].min(), compounds_df[Z_SCORE].max()
+        compounds_outside_df = None
+
+    # TBD: preserve this data somewhere
+    plot_compounds_df = prepare_data_plot(compounds_df, WELL, Z_SCORE)
+    range_max = len(plot_compounds_df)
+    plot_control_pos_df = prepare_data_plot(
+        control_pos_df, WELL, Z_SCORE, range_max=range_max
+    )
+    plot_control_neg_df = prepare_data_plot(
+        control_neg_df, WELL, Z_SCORE, range_max=range_max
+    )
 
     # to be updated
-    dfs = [compounds_df, control_pos_df, control_neg_df]
-    colors = ["rgb(66,167,244)", "rgb(0,255,0)", "rgb(255,0,0)"]
-    colors_shade = ["rgba(66,167,244,0.4)", "rgba(0,255,0,0.2)", "rgba(255,0,0,0.2)"]
-    names = ["COMPOUNDS", "CONTROL POS", "CONTROL NEG"]
+    dfs = [plot_control_pos_df, plot_control_neg_df, plot_compounds_df]
+    colors = ["rgb(0,128,0)", "rgb(255,0,0)", "rgb(31, 119, 180)"]
+    colors_shade = ["rgba(0,128,0,0.2)", "rgba(255,0,0,0.2)", "rgba(31, 119, 180,0.4)"]
+    names = ["CONTROL POS", "CONTROL NEG", "COMPOUNDS"]
 
     for i, df in enumerate(dfs):
         fig.add_trace(
             go.Scatter(
-                x=df["pos"],
+                x=df[id_pos],
                 y=df["mean"],
                 line=dict(color=colors[i]),
                 mode="lines",
                 name=names[i],
                 legendgroup=names[i],
-                hovertemplate=f"{WELL}: %{{x}}<br>z-score: %{{y:.2f}}<extra></extra>",  # TO IMPROVE
+                customdata=np.stack((df[WELL], df["std"]), axis=-1),
+                hovertemplate="well: %{customdata[0]}<br>avg z-score: %{y:.2f} &plusmn;%{customdata[1]:.2f}<extra></extra>",
             )
         )
 
         fig.add_trace(
             go.Scatter(
                 x=pd.concat(
-                    [df["pos"], df["pos"][::-1]], ignore_index=True
+                    [df[id_pos], df[id_pos][::-1]], ignore_index=True
                 ),  # well, then well reversed
                 y=pd.concat(
                     [df["ub"], df["lb"][::-1]], ignore_index=True
@@ -68,31 +101,56 @@ def plot_zscore(
             )
         )
 
+    if compounds_outside_df is not None:
+        compounds_outside_df = compounds_outside_df.merge(
+            plot_compounds_df[[WELL, id_pos]], on=WELL
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=compounds_outside_df[id_pos],
+                y=compounds_outside_df[Z_SCORE],
+                mode="markers",
+                marker=dict(color="rgb(31, 119, 180)", size=8),
+                name="COMPOUNDS OUTSIDE",
+                customdata=np.stack(
+                    (compounds_outside_df[PLATE], compounds_outside_df[WELL]), axis=-1
+                ),
+                hovertemplate="plate: %{customdata[0]}<br>well: %{customdata[1]}<br>z-score: %{y:.2f}<extra>CMPD ID</extra>",
+            )
+        )
+
+    fig.add_hline(
+        y=z_score_limits[0],
+        line_width=3,
+        line_dash="dash",
+        line_color="gray",
+        annotation_text=f"MIN: {z_score_limits[0]:.2f}",
+        annotation_font_color="gray",
+    )
+    fig.add_hline(
+        y=z_score_limits[1],
+        line_width=3,
+        line_dash="dash",
+        line_color="gray",
+        annotation_text=f"MAX: {z_score_limits[1]:.2f}",
+        annotation_font_color="gray",
+    )
+
     fig.update_xaxes(showticklabels=False)
     fig.update_layout(
         title=f"Z-score plot",
-        xaxis_title="Well",
+        # xaxis_title="Well",
+        xaxis=dict(
+            {
+                "title": "Well",
+                "visible": True,
+                "showticklabels": True,
+                "tickfont": {"size": 1, "color": "rgba(0,0,0,0)"},
+            }
+        ),
         yaxis_title="z-score",
         margin=dict(t=50, b=30, l=30, r=30),
         template=PLOTLY_TEMPLATE,
     )
-
-    if z_score_limits is not None:
-        fig.add_hline(
-            y=z_score_limits[0],
-            line_width=3,
-            line_dash="dash",
-            line_color="gray",
-            annotation_text=f"MIN: {z_score_limits[0]:.2f}",
-            annotation_font_color="gray",
-        )
-        fig.add_hline(
-            y=z_score_limits[1],
-            line_width=3,
-            line_dash="dash",
-            line_color="gray",
-            annotation_text=f"MAX: {z_score_limits[1]:.2f}",
-            annotation_font_color="gray",
-        )
 
     return fig


### PR DESCRIPTION
I updated `Z-score` plot, change it to the area plot and added the functionality we talked about (i.e. showing only the compounds as points that are outside pre-defined z-score range).

On `Z-score` range being changed the lines move  and when `Apply` button is clicked the changes are applied (points are shown).

Below I'm pasting the preview, highly encourage you to play with it/give some suggestions 🙏 (one thing we may decide upon is whether to sort the points according to `mean` or `std` value - as described on the screenshots it results in the main line/shaded area being respectively smoother/more spiky - **for now it is sorted wrt `std`**).

![obraz](https://github.com/zuzg/drug-screening/assets/82370491/ddcba760-1b53-42a0-9baf-452869f829f9)
![obraz](https://github.com/zuzg/drug-screening/assets/82370491/7938f90d-5cd3-459c-b6e8-19b758bac9d3)
![obraz](https://github.com/zuzg/drug-screening/assets/82370491/4f68f1cb-12ee-451c-8a6f-02cffb0c1cd7)
![obraz](https://github.com/zuzg/drug-screening/assets/82370491/72ae9180-c475-4289-be1a-05413b963177)

**NOTE 0:** I haven't done anything related to `act`/`inh` plots, sorry for the misleading branch name.
**NOTE 1:** z-score range on `RangeSlider` is computed basing on the values of compounds - in the beginning the range is maximal (includes all points, therefore no points are visible) + the button `Aply` is dsiabled until the range is computed.
**NOTE 2:** Due to the std of `COMPOUND POS` being very large, the initial view might be not pleasant (as visible on ss) but it can be switched off using the legend so imo it's not a problem.
**NOTE 3:** Last but not least - it takes a while 😉 (for the future we certainly need to add ↺, ⏳, 🔄 and stuff).