### PR TITLE
Add url to EOS datable

### DIFF
--- a/dashboard/assets/style.css
+++ b/dashboard/assets/style.css
@@ -172,3 +172,9 @@
     max-height: calc(100vh - 400px);
     overflow-y: auto;
 }
+
+ #echo-bmg-combined td.column-0 p {
+    margin-bottom: 0;
+    text-align : right;
+    justify-content: right;
+}

--- a/dashboard/data/utils.py
+++ b/dashboard/data/utils.py
@@ -1,13 +1,18 @@
 import pandas as pd
 
 
-# TODO: TO BE REMOVED???
-def generate_dummy_links_dataframe(compound_ids: list[str]) -> pd.DataFrame:
-    eos = [
-        f"[EOS{i+1}](https://ecbd.eu/compound/EOS{i+1})"
-        for i, _ in enumerate(compound_ids)
-    ]
-    return pd.DataFrame({"CMPD ID": compound_ids, "EOS": eos}).set_index("CMPD ID")
+def eos_to_ecbd_link(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Change eos to url to that eos in provided dataframe
+
+    :param df: dataframe with EOS column
+    :return: dataframe with eoses as urls
+    """
+    df_links = df.copy()
+    df_links["EOS"] = df_links["EOS"].apply(
+        lambda eos: f"[{eos}](https://ecbd.eu/compound/{eos})"
+    )
+    return df_links
 
 
 def is_chemical_result(column_name: str) -> bool:

--- a/dashboard/pages/screening/callbacks.py
+++ b/dashboard/pages/screening/callbacks.py
@@ -19,6 +19,7 @@ from dashboard.data.combine import (
     split_compounds_controls,
 )
 from dashboard.data.file_preprocessing.echo_files_parser import EchoFilesParser
+from dashboard.data.utils import eos_to_ecbd_link
 from dashboard.pages.components import make_file_list_component
 from dashboard.report.generate_jinja_report import generate_jinja_report
 from dashboard.storage import FileStorage
@@ -356,8 +357,10 @@ def on_summary_entry(
         (inhibition_min, inhibition_max),
     )
 
+    compounds_url_df = eos_to_ecbd_link(compounds_df)
+
     return (
-        compounds_df.to_dict("records"),
+        compounds_url_df.to_dict("records"),
         fig_z_score,
         fig_activation,
         fig_inhibition,

--- a/dashboard/pages/screening/stages/s5_summary.py
+++ b/dashboard/pages/screening/stages/s5_summary.py
@@ -6,7 +6,7 @@ PRECISION = 5
 _ACT_INH_DATATABLE = dash_table.DataTable(
     id="echo-bmg-combined",
     columns=[
-        dict(id="EOS", name="ID"),
+        dict(id="EOS", name="ID", type="text", presentation="markdown"),
         dict(id="Destination Plate Barcode", name="Plate Barcode"),
         dict(id="Destination Well", name="Well"),
         dict(


### PR DESCRIPTION
Resolves: #122 

Clicking on EOS now redirects to ecbd page with selected compound.
![image](https://github.com/zuzg/drug-screening/assets/81712088/c8e0e0e4-36fa-46c7-93d3-eae76e1846a4)
![image](https://github.com/zuzg/drug-screening/assets/81712088/09279596-0ef7-4894-9432-bba27fc4d7ca)

🆘**HELP NEEDED**🆘
I wasn't able to align links to the right (as rest of the table is). I tried `textAlign` parameter in `style_cell`, custom styling in css (it worked only with `p` selector, but also broke other stylings) [source](https://community.plotly.com/t/maintaining-formatting-with-markdown-in-datatable/52013/3)
Alternative solution is to adjust all the cells to the right 😶‍🌫️