### PR TITLE
closes 138 control hit plot

### DIFF
--- a/dashboard/data/determination.py
+++ b/dashboard/data/determination.py
@@ -147,5 +147,6 @@ def perform_hit_determination(
     activation_df = aggregated_df.merge(
         curve_fit_df, how="inner", left_on="EOS", right_on="EOS"
     ).rename(columns=rename_dict)
-
+    activation_df["TOP"] = activation_df["upper_limit"]
+    activation_df["BOTTOM"] = activation_df["lower_limit"]
     return process_activation_df(activation_df)

--- a/dashboard/pages/hit_validation/callbacks.py
+++ b/dashboard/pages/hit_validation/callbacks.py
@@ -300,8 +300,8 @@ def on_selected_compound_changed(
             ]
         ),
         "graph": graph,
-        "top": entry["TOP"],
-        "bottom": entry["BOTTOM"],
+        "top": round(entry["TOP"], 5),
+        "bottom": round(entry["BOTTOM"], 5),
     }
     return tuple(result.values())
 

--- a/dashboard/pages/hit_validation/stages/s2_hit_browser.py
+++ b/dashboard/pages/hit_validation/stages/s2_hit_browser.py
@@ -71,25 +71,78 @@ RIGHT_PANEL = html.Div(
                 html.Div(
                     className="d-flex flex-column h-100 flex-grow-1",
                     children=[
-                        html.Div(
+                        html.Section(
+                            children=[
+                                html.Div(
+                                    children=[
+                                        html.Span(
+                                            param["label"] + ":",
+                                            className="fw-bold fixed-width-150",
+                                        ),
+                                        html.Span(
+                                            children=[
+                                                html.Span("-", id=param["id"]),
+                                                html.Span(
+                                                    param["units"],
+                                                    style={"width": "2rem"},
+                                                ),
+                                            ],
+                                            className="d-flex flex-row gap-2",
+                                        ),
+                                    ],
+                                    className="d-flex flex-row w-100 gap-4 justify-content-between border-bottom border-1",
+                                )
+                                for param in PARAMS_DISPLAY_SPEC
+                            ]
+                        ),
+                        html.Section(
+                            className="mt-5 d-flex flex-column gap-3",
                             children=[
                                 html.Span(
-                                    param["label"] + ":",
-                                    className="fw-bold fixed-width-150",
+                                    children=[
+                                        html.Label(
+                                            "TOP Override:",
+                                            className="form-label",
+                                        ),
+                                        dcc.Input(
+                                            id="hit-browser-top",
+                                            type="number",
+                                            placeholder="Top",
+                                            className="form-control",
+                                        ),
+                                    ],
                                 ),
                                 html.Span(
                                     children=[
-                                        html.Span("-", id=param["id"]),
-                                        html.Span(
-                                            param["units"], style={"width": "2rem"}
+                                        html.Label(
+                                            "BOTTOM Override:",
+                                            className="form-label",
+                                        ),
+                                        dcc.Input(
+                                            id="hit-browser-bottom",
+                                            type="number",
+                                            placeholder="Bottom",
+                                            className="form-control",
                                         ),
                                     ],
-                                    className="d-flex flex-row gap-2",
+                                ),
+                                html.Span(
+                                    className="d-flex flex-row gap-3 w-100",
+                                    children=[
+                                        html.Button(
+                                            id="hit-browser-apply-button",
+                                            className="btn btn-primary flex-grow-1",
+                                            children="Apply Stacking",
+                                        ),
+                                        html.Button(
+                                            id="hit-browser-unstack-button",
+                                            className="btn btn-primary flex-grow-1",
+                                            children="Unstack",
+                                        ),
+                                    ],
                                 ),
                             ],
-                            className="d-flex flex-row w-100 gap-4 justify-content-between border-bottom border-1",
-                        )
-                        for param in PARAMS_DISPLAY_SPEC
+                        ),
                     ],
                 ),
             ],

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -545,8 +545,8 @@ def plot_ic50(entry: dict, x: np.ndarray, y: np.ndarray) -> go.Figure:
         fit_x = np.logspace(np.log10(x.min()), np.log10(x.max()), 100)
         fit_y = four_param_logistic(
             fit_x,
-            entry["lower_limit"],
-            entry["upper_limit"],
+            entry["BOTTOM"],
+            entry["TOP"],
             entry["ic50"],
             entry["slope"],
         )
@@ -565,8 +565,8 @@ def plot_ic50(entry: dict, x: np.ndarray, y: np.ndarray) -> go.Figure:
                 y=[
                     four_param_logistic(
                         entry["ic50"],
-                        entry["lower_limit"],
-                        entry["upper_limit"],
+                        entry["BOTTOM"],
+                        entry["TOP"],
                         entry["ic50"],
                         entry["slope"],
                     )


### PR DESCRIPTION
Implemented stacking control for Hit Determination chart, user may now define the bounds for the fitted function
As a side effect it also shows the user initial lower/upper limit

tbd if that should impact how activity/r2 is calculated 

default bounds:
<img width="1027" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/db33a2f9-afe0-4dd3-867a-4b18f45248ef">

stacking applied:
<img width="1014" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/03d47b35-f69f-40ab-b87f-0663fb02835c">

modified TOP/BOTTOM is saved in the resulting CSV file
unstacking brings back original values

