### PR TITLE
closes 140 configuration for hit determination

### DIFF
--- a/dashboard/data/determination.py
+++ b/dashboard/data/determination.py
@@ -160,7 +160,7 @@ def perform_hit_determination(
     activation_df = aggregated_df.merge(
         curve_fit_df, how="inner", left_on="EOS", right_on="EOS"
     ).rename(columns=rename_dict)
-    
+
     activation_df["TOP"] = activation_df["upper_limit"]
     activation_df["BOTTOM"] = activation_df["lower_limit"]
 

--- a/dashboard/data/determination.py
+++ b/dashboard/data/determination.py
@@ -70,19 +70,25 @@ def curve_fit_for_activation(screen_df: pd.DataFrame) -> pd.DataFrame:
     return curve_fit_df.set_index("EOS")
 
 
-ACTIVITY_THRESHOLD = 10
-MAX_MIN_VALUE_THRESHOLD = 75
-MIN_MAX_VALUE_THRESHOLD = 30
-IC50_THRESHOLD = 10
-UPPER_LIMIT_LOWER_BOUND = 30
-UPPER_LIMIT_UPPER_BOUND = 80
+MAX_MIN_VALUE_THRESHOLD = 75  # Keep
+MIN_MAX_VALUE_THRESHOLD = 30  # Keep
 
 
-def process_activation_df(activation_df: pd.DataFrame) -> pd.DataFrame:
+def process_activation_df(
+    activation_df: pd.DataFrame,
+    concentration_lower_bound: float,
+    concentration_upper_bound: float,
+    top_lower_bound: float,
+    top_upper_bound: float,
+) -> pd.DataFrame:
     """
     Performs the final processing of the activation dataframe.
 
     :param activation_df: activation dataframe
+    :param concentration_lower_bound: lower bound for concentration
+    :param concentration_upper_bound: upper bound for concentration
+    :param top_lower_bound: lower bound for top
+    :param top_upper_bound: upper bound for top
     :return: processed activation dataframe with determined activity
     """
     activation_df["all_conc_active"] = (
@@ -98,30 +104,35 @@ def process_activation_df(activation_df: pd.DataFrame) -> pd.DataFrame:
         np.where(activation_df.all_conc_inactive, ">", activation_df.operator),
     )
     activation_df["is_reverse_dose"] = activation_df.slope < 0
-    activation_df["is_active"] = activation_df.ic50 < ACTIVITY_THRESHOLD
+    activation_df["is_active"] = (activation_df.ic50 < concentration_upper_bound) & (
+        activation_df.ic50 > concentration_lower_bound
+    )
     activation_df["activity_final"] = np.where(
         activation_df.operator != "=",
         "inconclusive",
         np.where(
-            (activation_df.ic50 >= IC50_THRESHOLD)
-            | (activation_df.upper_limit <= UPPER_LIMIT_LOWER_BOUND),
+            (activation_df.ic50 >= concentration_upper_bound)
+            | (activation_df.ic50 <= concentration_lower_bound)
+            | (activation_df.upper_limit <= top_lower_bound),
             "inactive",
             "active",
         ),
     )
     activation_df["is_partially_active"] = (
-        (activation_df.upper_limit > UPPER_LIMIT_LOWER_BOUND)
-        & (activation_df.upper_limit < UPPER_LIMIT_UPPER_BOUND)
-        & (activation_df.ic50 < IC50_THRESHOLD)
+        (activation_df.upper_limit > top_lower_bound)
+        & (activation_df.upper_limit < top_upper_bound)
+        & (activation_df.ic50 < concentration_upper_bound)
+        & (activation_df.ic50 > concentration_lower_bound)
     )
     return activation_df
 
 
-# TODO: use bounds, allow to customize limits/constants
 def perform_hit_determination(
     screen_df: pd.DataFrame,
     concentration_lower_bound: float,
     concentration_upper_bound: float,
+    top_lower_bound: float,
+    top_upper_bound: float,
 ) -> pd.DataFrame:
     """
     Performs hit determination on the screening data.
@@ -129,6 +140,8 @@ def perform_hit_determination(
     :param screen_df: screening data
     :param concentration_lower_bound: lower bound for concentration
     :param concentration_upper_bound: upper bound for concentration
+    :param top_lower_bound: lower bound for top
+    :param top_upper_bound: upper bound for top
     :return: hit determination data
     """
     sorted_df = screen_df.sort_values(by=["EOS", "CONCENTRATION"])
@@ -148,4 +161,10 @@ def perform_hit_determination(
         curve_fit_df, how="inner", left_on="EOS", right_on="EOS"
     ).rename(columns=rename_dict)
 
-    return process_activation_df(activation_df)
+    return process_activation_df(
+        activation_df,
+        concentration_lower_bound,
+        concentration_upper_bound,
+        top_lower_bound,
+        top_upper_bound,
+    )

--- a/dashboard/pages/hit_validation/callbacks.py
+++ b/dashboard/pages/hit_validation/callbacks.py
@@ -34,6 +34,8 @@ def on_file_upload(
     stored_uuid: str,
     concentration_lower_bound: float,
     concentration_upper_bound: float,
+    top_lower_bound: float,
+    top_upper_bound: float,
     file_storage: FileStorage,
 ) -> html.Div:
     """
@@ -44,6 +46,8 @@ def on_file_upload(
     :param stored_uuid: session uuid
     :param concentration_lower_bound: concentration lower bound
     :param concentration_upper_bound: concentration upper bound
+    :param top_lower_bound: top lower bound
+    :param top_upper_bound: top upper bound
     :param file_storage: file storage
     :return: icon indicating the status of the upload
     """
@@ -102,7 +106,11 @@ def on_file_upload(
 
     # Placeholder for hit determination
     hit_determination_df = perform_hit_determination(
-        screen_df, concentration_lower_bound, concentration_upper_bound
+        screen_df,
+        concentration_lower_bound,
+        concentration_upper_bound,
+        top_lower_bound,
+        top_upper_bound,
     )
     unfit = hit_determination_df.EOS[hit_determination_df.ic50.isna()].tolist()
 
@@ -315,6 +323,8 @@ def register_callbacks(elements, file_storage: FileStorage):
         State("user-uuid", "data"),
         State("concentration-lower-bound-store", "data"),
         State("concentration-upper-bound-store", "data"),
+        State("top-lower-bound-store", "data"),
+        State("top-upper-bound-store", "data"),
     )(functools.partial(on_file_upload, file_storage=file_storage))
 
     callback(

--- a/dashboard/pages/hit_validation/callbacks.py
+++ b/dashboard/pages/hit_validation/callbacks.py
@@ -154,21 +154,20 @@ FAIL_BOUNDS_ELEMENT = html.Div(
 )
 
 
-def on_concentration_bounds_change(
+def on_bounds_change(
     lower_bound: float, upper_bound: float
 ) -> tuple[float, float, html.Div]:
     """
-    Callback for concentration bounds change. It checks if the lower bound is greater
+    Callback for bounds change. It checks if the lower bound is greater
     than the upper bound.
 
     :param lower_bound: lower bound
     :param upper_bound: upper bound
     :return: icon indicating the status of the bounds
     """
-    if lower_bound > upper_bound:
-        return no_update, no_update, FAIL_BOUNDS_ELEMENT, {}
-    report_data = {"lower_bound": lower_bound, "upper_bound": upper_bound}
-    return lower_bound, upper_bound, "", report_data
+    if lower_bound is None or upper_bound is None or lower_bound > upper_bound:
+        return no_update, no_update, FAIL_BOUNDS_ELEMENT
+    return lower_bound, upper_bound, ""
 
 
 # === STAGE 2 ===
@@ -321,11 +320,17 @@ def register_callbacks(elements, file_storage: FileStorage):
     callback(
         Output("concentration-lower-bound-store", "data"),
         Output("concentration-upper-bound-store", "data"),
-        Output("parameters-message", "children"),
-        Output("report-data-hit-validation-input", "data"),
+        Output("concentration-parameters-message", "children"),
         Input("concentration-lower-bound-input", "value"),
         Input("concentration-upper-bound-input", "value"),
-    )(on_concentration_bounds_change)
+    )(on_bounds_change)
+    callback(
+        Output("top-lower-bound-store", "data"),
+        Output("top-upper-bound-store", "data"),
+        Output("top-parameters-message", "children"),
+        Input("top-lower-bound-input", "value"),
+        Input("top-upper-bound-input", "value"),
+    )(on_bounds_change)
 
     callback(
         Output("compounds-list-container", "children"),

--- a/dashboard/pages/hit_validation/callbacks.py
+++ b/dashboard/pages/hit_validation/callbacks.py
@@ -286,11 +286,22 @@ def on_selected_compound_changed(
 
 def on_json_generate_button_click(
     n_clicks,
-    correlation_plots_report,
+    concentration_lower_bound: float,
+    concentration_upper_bound: float,
+    top_lower_bound: float,
+    top_upper_bound: float,
     file_storage: FileStorage,
 ):
     filename = f"hit_validation_settings_{datetime.now().strftime('%Y-%m-%d')}.json"
-    json_object = json.dumps(correlation_plots_report, indent=4)
+    json_object = json.dumps(
+        {
+            "concentration_lower_bound": concentration_lower_bound,
+            "concentration_upper_bound": concentration_upper_bound,
+            "top_lower_bound": top_lower_bound,
+            "top_upper_bound": top_upper_bound,
+        },
+        indent=4,
+    )
     return dict(content=json_object, filename=filename)
 
 
@@ -372,7 +383,10 @@ def register_callbacks(elements, file_storage: FileStorage):
     callback(
         Output("download-json-settings-hit-validation", "data"),
         Input("generate-json-button", "n_clicks"),
-        State("report-data-hit-validation-input", "data"),
+        State("concentration-lower-bound-store", "data"),
+        State("concentration-upper-bound-store", "data"),
+        State("top-lower-bound-store", "data"),
+        State("top-upper-bound-store", "data"),
         prevent_initial_call=True,
     )(functools.partial(on_json_generate_button_click, file_storage=file_storage))
 

--- a/dashboard/pages/hit_validation/page.py
+++ b/dashboard/pages/hit_validation/page.py
@@ -24,6 +24,8 @@ pb.extend_layout(
         children=[
             dcc.Store(id="concentration-lower-bound-store", data=0),
             dcc.Store(id="concentration-upper-bound-store", data=10),
+            dcc.Store(id="top-lower-bound-store", data=30),
+            dcc.Store(id="top-upper-bound-store", data=80),
         ]
     )
 )

--- a/dashboard/pages/hit_validation/stages/s1_screening_data_input.py
+++ b/dashboard/pages/hit_validation/stages/s1_screening_data_input.py
@@ -3,41 +3,83 @@ from dash import html, dcc
 PARAMS_CONTAINER = html.Div(
     children=[
         html.H5(
-            children="Determination Parameters",
+            children="Activity Determination Parameters",
         ),
         html.Div(
             children=[
                 html.Div(
+                    className="d-flex flex-column flex-grow-1 w-100",
                     children=[
-                        html.Label(
-                            children="Concentration lower bound (µM)",
-                            className="form-label",
+                        html.Span(
+                            children=[
+                                html.Label(
+                                    children="Concentration upper bound (µM)",
+                                    className="form-label",
+                                ),
+                                dcc.Input(
+                                    id="concentration-upper-bound-input",
+                                    type="number",
+                                    value=10,
+                                    min=0,
+                                    className="form-control",
+                                ),
+                            ],
+                            className="flex-grow-1",
                         ),
-                        dcc.Input(
-                            id="concentration-lower-bound-input",
-                            type="number",
-                            value=0,
-                            min=0,
-                            className="form-control",
+                        html.Span(
+                            children=[
+                                html.Label(
+                                    children="Concentration lower bound (µM)",
+                                    className="form-label",
+                                ),
+                                dcc.Input(
+                                    id="concentration-lower-bound-input",
+                                    type="number",
+                                    value=0,
+                                    min=0,
+                                    className="form-control",
+                                ),
+                            ],
+                            className="flex-grow-1",
                         ),
                     ],
-                    className="flex-grow-1",
                 ),
                 html.Div(
+                    className="d-flex flex-column flex-grow-1 w-100",
                     children=[
-                        html.Label(
-                            children="Concentration upper bound (µM)",
-                            className="form-label",
+                        html.Span(
+                            children=[
+                                html.Label(
+                                    children="Top Upper Bound (%)",
+                                    className="form-label",
+                                ),
+                                dcc.Input(
+                                    id="top-upper-bound-input",
+                                    type="number",
+                                    value=80,
+                                    min=0,
+                                    className="form-control",
+                                ),
+                            ],
+                            className="flex-grow-1",
                         ),
-                        dcc.Input(
-                            id="concentration-upper-bound-input",
-                            type="number",
-                            value=10,
-                            min=0,
-                            className="form-control",
+                        html.Span(
+                            children=[
+                                html.Label(
+                                    children="Top Lower Bound (%)",
+                                    className="form-label",
+                                ),
+                                dcc.Input(
+                                    id="top-lower-bound-input",
+                                    type="number",
+                                    value=30,
+                                    min=0,
+                                    className="form-control",
+                                ),
+                            ],
+                            className="flex-grow-1",
                         ),
                     ],
-                    className="flex-grow-1",
                 ),
             ],
             className="d-flex flex-row justify-content-evenly gap-5",
@@ -90,9 +132,18 @@ SCREENING_INPUT_STAGE = html.Div(
     className="container",
     children=[
         PARAMS_CONTAINER,
-        html.Div(
-            id="parameters-message",
-            className="d-flex flex-row align-items-center justify-content-center",
+        html.Span(
+            className="d-flex flex-row justify-content-between gap-5",
+            children=[
+                html.Div(
+                    id="concentration-parameters-message",
+                    className="d-flex flex-row align-items-center justify-content-center",
+                ),
+                html.Div(
+                    id="top-parameters-message",
+                    className="d-flex flex-row align-items-center justify-content-center",
+                ),
+            ],
         ),
         html.Hr(),
         FILE_INPUT_CONTAINER,

--- a/dashboard/pages/hit_validation/stages/s1_screening_data_input.py
+++ b/dashboard/pages/hit_validation/stages/s1_screening_data_input.py
@@ -101,6 +101,12 @@ FILE_INPUT_CONTAINER = html.Div(
                 html.Div(
                     children=[
                         html.P(SCREENING_DESC, className="text-justify"),
+                        html.P(
+                            children=[
+                                html.Span("Note: ", className="fw-bold"),
+                                "after changing the parameters, the file needs to be re-uploaded.",
+                            ]
+                        ),
                     ],
                 ),
                 html.Div(


### PR DESCRIPTION
Extended configuration with top bounds; now the activity determination uses the configured values instead of predefined constants - albeit the default values equal the ones from KNIME workflow.
This allows the user to influence the rules on how to classify activity of the compounds:
<img width="1012" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/fff2fa63-c44f-45b9-bf6a-2383b548cf5c">

Proof of work - classification of **EOS100028**:
---

default settings - classified as ACTIVE as IC50 <= 10 & IC50 > 0 AND TOP > 30:
<img width="1004" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/cc412f9f-28f2-4709-bca8-f81f692ef1f8">

classification with set concentration upper bound for IC50 to 0.5 - classified as INACTIVE:
<img width="1020" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/b69ef552-3f55-4a23-931b-5093de16e6dd">


As previously discussed - constants for `ALL_CONC_ACTIVE` and `ALL_CONC_INACTIVE` features remain as such.
Note - as the determination is calculated whenever the file is uploaded, after changing the configuration that file needs to be re-uploaded to reflect new configuration.



