### PR TITLE
Add structural similarity

### DIFF
--- a/dashboard/data/structural_similarity.py
+++ b/dashboard/data/structural_similarity.py
@@ -37,7 +37,7 @@ def compute_ecfp_descriptors(smiles_list: List[str]) -> Tuple[np.ndarray, int]:
     descriptors = []
     for i, smiles in enumerate(smiles_list):
         ecfp = _compute_single_ecfp_descriptor(smiles)
-        if ecfp:
+        if ecfp is not None:
             keep_idx.append(i)
             descriptors.append(ecfp)
     return np.vstack(descriptors), keep_idx

--- a/dashboard/data/structural_similarity.py
+++ b/dashboard/data/structural_similarity.py
@@ -3,8 +3,6 @@ from typing import List, Optional, Tuple
 import hdbscan
 import numpy as np
 import pandas as pd
-import plotly.express as px
-import plotly.graph_objects as go
 import umap
 from rdkit import Chem
 from rdkit.Chem import AllChem
@@ -128,75 +126,3 @@ def prepare_cluster_viz(
     df["PCA_0"], df["PCA_1"] = X_pca[:, 0], X_pca[:, 1]
     df["cluster_PCA"] = calculate_clusters(X_pca)
     return df
-
-
-def plot_clustered_smiles(
-    df: pd.DataFrame,
-    feature: str = "activity_final",
-    projection: str = "PCA",
-) -> go.Figure:
-    """
-    Plot selected projection and colour points with respect to selected feature.
-
-    :param df: DataFrame to be visualized
-    :param feature: name of the column with respect to which the plot will be coloured
-    :param projection: name of projection to be visualized
-
-    :return: plotly express scatter plot
-    """
-    projection_x = f"{projection.upper()}_0"
-    projection_y = f"{projection.upper()}_1"
-    clusters = f"cluster_{projection}"
-    labels = {
-        projection_x: "X",
-        projection_y: "Y",
-        "EOS": "EOS",
-        feature: "Activity",
-        clusters: "Cluster",
-    }
-    hover_data = {
-        "EOS": True,
-        projection_x: ":.3f",
-        projection_y: ":.3f",
-        feature: True,
-        clusters: True,
-    }
-    fig = px.scatter(
-        df[df[clusters] != "outlier"],
-        x=projection_x,
-        y=projection_y,
-        color=feature,
-        color_discrete_sequence=["#00CC96", "#FFA15A", "#636EFA"],
-        symbol=clusters,
-        opacity=0.7,
-        labels=labels,
-        title=f"{projection.upper()} projection of SMILES with respect to activity",
-        hover_data=hover_data,
-    )
-    fig.add_traces(
-        px.scatter(
-            df[df[clusters] == "outlier"],
-            x=projection_x,
-            y=projection_y,
-            labels=labels,
-            hover_data=hover_data,
-        )
-        .update_traces(
-            marker_color="gray",
-            marker_symbol="x",
-            opacity=0.3,
-            name="outliers",
-            showlegend=True,
-        )
-        .data
-    )
-
-    fig.update_yaxes(title_standoff=15, automargin=True)
-    fig.update_xaxes(title_standoff=30, automargin=True)
-    fig.update_layout(
-        modebar=dict(orientation="v"),
-        margin=dict(r=35, l=15, b=0),
-        title_x=0.5,
-        template="plotly_white",
-    )
-    return fig

--- a/dashboard/data/structural_similarity.py
+++ b/dashboard/data/structural_similarity.py
@@ -1,0 +1,135 @@
+from typing import List, Optional, Tuple
+
+import hdbscan
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import umap
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from sklearn.decomposition import PCA
+
+
+def _compute_single_ecfp_descriptor(smiles: str) -> Optional[np.ndarray]:
+    mol = Chem.MolFromSmiles(smiles)
+    if mol:
+        fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius=2, nBits=2048)
+        return np.array(fp)
+    return None
+
+
+def compute_ecfp_descriptors(smiles_list: List[str]) -> Tuple[np.ndarray, int]:
+    keep_idx = []
+    descriptors = []
+    for i, smiles in enumerate(smiles_list):
+        ecfp = _compute_single_ecfp_descriptor(smiles)
+        if ecfp:
+            keep_idx.append(i)
+            descriptors.append(ecfp)
+    return np.vstack(descriptors), keep_idx
+
+
+def merge_active_new(
+    activity: pd.DataFrame, smiles_active: pd.DataFrame, smiles_new: pd.DataFrame
+) -> pd.DataFrame:
+    merged = smiles_active.merge(activity, on="EOS")
+    smiles_new["activity_final"] = "not tested"
+    smiles_new = smiles_new.rename(columns={"eos": "EOS"})
+    merged = pd.concat([merged, smiles_new])
+    merged = merged.drop_duplicates(subset=["EOS"])
+    return merged
+
+
+def calculate_umap(descriptors: np.ndarray) -> np.ndarray:
+    umap_model = umap.UMAP(
+        metric="jaccard",
+        n_neighbors=25,
+        n_components=2,
+        low_memory=False,
+        min_dist=0.001,
+    )
+    X_umap = umap_model.fit_transform(descriptors)
+    return X_umap
+
+
+def calculate_pca(descriptors: np.ndarray) -> np.ndarray:
+    pca_model = PCA(n_components=2)
+    X_pca = pca_model.fit_transform(descriptors)
+    return X_pca
+
+
+def calculate_clusters(x_projection: np.ndarray) -> np.ndarray:
+    hdbscan_model = hdbscan.HDBSCAN(
+        min_cluster_size=20, min_samples=20, cluster_selection_method="eom"
+    )
+
+    return hdbscan_model.fit_predict(x_projection)
+
+
+def prepare_cluster_viz(
+    activity: pd.DataFrame, smiles_active: pd.DataFrame, smiles_new: pd.DataFrame
+) -> pd.DataFrame:
+    df = merge_active_new(activity, smiles_active, smiles_new)
+    ecfp_descriptors, keep_idx = compute_ecfp_descriptors(df["smiles"])
+    df = df.iloc[keep_idx]
+    X_umap = calculate_umap(ecfp_descriptors)
+    df["UMAP_0"], df["UMAP_1"] = X_umap[:, 0], X_umap[:, 1]
+    df["cluster_UMAP"] = calculate_clusters(X_umap)
+    X_pca = calculate_pca(ecfp_descriptors)
+    df["PCA_0"], df["PCA_1"] = X_pca[:, 0], X_pca[:, 1]
+    df["cluster_PCA"] = calculate_clusters(X_pca)
+    return df
+
+
+def plot_clustered_smiles(
+    df: pd.DataFrame,
+    feature: str = "activity_final",
+    projection: str = "PCA",
+) -> go.Figure:
+    """
+    Plot selected projection and colour points with respect to selected feature.
+
+    :param df: DataFrame to be visualized
+    :param feature: name of the column with respect to which the plot will be coloured
+    :param projection: name of projection to be visualized
+
+    :return: plotly express scatter plot
+    """
+    projection_x = f"{projection.upper()}_0"
+    projection_y = f"{projection.upper()}_1"
+    clusters = f"cluster_{projection}"
+    fig = px.scatter(
+        df,
+        x=projection_x,
+        y=projection_y,
+        color=feature,
+        color_discrete_sequence=["rgb(0,128,0)", "yellow", "rgb(31, 119, 180)"],
+        symbol=clusters,
+        opacity=0.5,
+        labels={
+            projection_x: "X",
+            projection_y: "Y",
+            "EOS": "EOS",
+            feature: "activity",
+        },
+        title=f"{projection.upper()} projection of SMILES with respect to activity",
+        hover_data={
+            "EOS": True,
+            projection_x: ":.3f",
+            projection_y: ":.3f",
+            feature: True,
+            clusters: ":.3d",
+        },
+    )
+
+    fig.update_yaxes(title_standoff=15, automargin=True)
+    fig.update_xaxes(title_standoff=30, automargin=True)
+    fig.update_layout(
+        modebar=dict(orientation="v"),
+        margin=dict(r=35, l=15, b=0),
+        title_x=0.5,
+        template="plotly_white",
+    )
+    return fig

--- a/dashboard/pages/data_projection/callbacks.py
+++ b/dashboard/pages/data_projection/callbacks.py
@@ -317,7 +317,7 @@ def on_smiles_files_upload(
     return (
         html.Div(
             children=[
-                make_file_list_component([activity_decoded, smiles_decoded], [], 1),
+                make_file_list_component([filenames], [], 1),
             ],
         ),
     )
@@ -343,10 +343,9 @@ def on_plot_smiles(
     if current_stage != 4:
         return no_update
 
-    # df = pd.read_parquet(
-    #     pa.BufferReader(file_storage.read_file(f"{stored_uuid}_smiles_merged.pq")),
-    # )
-    df = pd.read_parquet("/home/zuz-gaw/uni/drug-screening/notebooks/smiles_merged.pq")
+    df = pd.read_parquet(
+        pa.BufferReader(file_storage.read_file(f"{stored_uuid}_smiles_merged.pq")),
+    )
 
     fig = plot_clustered_smiles(df)
     projections_df = eos_to_ecbd_link(df)[
@@ -385,10 +384,9 @@ def on_smiles_dropdown_checkbox_change(
     :param file_storage: file storage
     :return: figure with projections"""
 
-    # df = pd.read_parquet(
-    #     pa.BufferReader(file_storage.read_file(f"{stored_uuid}_smiles_merged.pq")),
-    # )
-    df = pd.read_parquet("/home/zuz-gaw/uni/drug-screening/notebooks/smiles_merged.pq")
+    df = pd.read_parquet(
+        pa.BufferReader(file_storage.read_file(f"{stored_uuid}_smiles_merged.pq")),
+    )
     return plot_clustered_smiles(df, projection=projection_type)
 
 
@@ -442,7 +440,7 @@ def register_callbacks(elements, file_storage: FileStorage):
         Input("upload-smiles-data", "contents"),
         State("user-uuid", "data"),
         prevent_initial_call=True,
-    )(functools.partial(on_projection_files_upload, file_storage=file_storage))
+    )(functools.partial(on_smiles_files_upload, file_storage=file_storage))
     callback(
         Output("smiles-projection-plot", "figure", allow_duplicate=True),
         Output("smiles-projection-table", "children"),

--- a/dashboard/pages/data_projection/callbacks.py
+++ b/dashboard/pages/data_projection/callbacks.py
@@ -281,9 +281,10 @@ def on_save_projections_click(
 
 def on_smiles_files_upload(
     contents: str | None,
-    filenames: List[str],
+    filename: str,
     last_modified: int,
     smiles_content: str | None,
+    smiles_filename: str,
     stored_uuid: str | None,
     file_storage: FileStorage,
 ) -> Tuple[html.Div, str]:
@@ -317,7 +318,7 @@ def on_smiles_files_upload(
     return (
         html.Div(
             children=[
-                make_file_list_component([filenames], [], 1),
+                make_file_list_component([filename, smiles_filename], [], 1),
             ],
         ),
     )
@@ -349,7 +350,7 @@ def on_plot_smiles(
 
     fig = plot_clustered_smiles(df)
     projections_df = eos_to_ecbd_link(df)[
-        ["EOS", "smiles", "activity_final", "cluster_PCA", "cluster_UMAP"]
+        ["EOS", "activity_final", "cluster_PCA", "cluster_UMAP"]
     ]
     table = table_from_df(projections_df, "projection-table")
 
@@ -438,6 +439,7 @@ def register_callbacks(elements, file_storage: FileStorage):
         Input("upload-activity-data", "filename"),
         Input("upload-activity-data", "last_modified"),
         Input("upload-smiles-data", "contents"),
+        Input("upload-smiles-data", "filename"),
         State("user-uuid", "data"),
         prevent_initial_call=True,
     )(functools.partial(on_smiles_files_upload, file_storage=file_storage))

--- a/dashboard/pages/data_projection/callbacks.py
+++ b/dashboard/pages/data_projection/callbacks.py
@@ -15,14 +15,15 @@ from sklearn.decomposition import PCA
 
 from dashboard.data.controls import controls_index_annotator, generate_controls
 from dashboard.data.preprocess import MergedAssaysPreprocessor
-from dashboard.data.structural_similarity import (
-    prepare_cluster_viz,
-    plot_clustered_smiles,
-)
+from dashboard.data.structural_similarity import prepare_cluster_viz
 from dashboard.data.utils import eos_to_ecbd_link
 from dashboard.pages.components import make_file_list_component
 from dashboard.storage import FileStorage
-from dashboard.visualization.plots import make_projection_plot, plot_projection_2d
+from dashboard.visualization.plots import (
+    make_projection_plot,
+    plot_projection_2d,
+    plot_clustered_smiles,
+)
 from dashboard.visualization.text_tables import pca_summary, table_from_df
 
 PROJECTION_SETUP = [
@@ -42,7 +43,7 @@ PROJECTION_SETUP = [
 
 def on_projection_files_upload(
     content: str | None,
-    filenames: list[str],
+    filenames: List[str],
     last_modified: int,
     stored_uuid: str,
     file_storage: FileStorage,
@@ -197,7 +198,7 @@ def on_projections_visualization_entry(
 def on_dropdown_checkbox_change(
     projection_type: str,
     attribute: str,
-    controls: list[str],
+    controls: List[str],
     stored_uuid: str,
     file_storage: FileStorage,
 ) -> go.Figure:

--- a/dashboard/pages/data_projection/callbacks.py
+++ b/dashboard/pages/data_projection/callbacks.py
@@ -3,7 +3,7 @@ import functools
 import io
 import uuid
 from datetime import datetime
-from typing import List
+from typing import List, Tuple
 
 import pandas as pd
 import plotly.graph_objects as go
@@ -46,7 +46,7 @@ def on_projection_files_upload(
     last_modified: int,
     stored_uuid: str,
     file_storage: FileStorage,
-) -> tuple[html.Div, str]:
+) -> Tuple[html.Div, str]:
     """
     Callback for file upload. TBD
 
@@ -94,7 +94,7 @@ def on_projections_visualization_entry(
     current_stage: int,
     stored_uuid: str,
     file_storage: FileStorage,
-) -> tuple[go.Figure, html.Div, html.Div, html.Div, html.Div, html.Div]:
+) -> Tuple[go.Figure, html.Div, html.Div, html.Div, html.Div, html.Div]:
     """
     Callback for projections visualization stage entry.
     It loads the data from the storage, computes and visualizes the projections.
@@ -286,7 +286,7 @@ def on_smiles_files_upload(
     smiles_content: str | None,
     stored_uuid: str | None,
     file_storage: FileStorage,
-) -> tuple[html.Div, str]:
+) -> Tuple[html.Div, str]:
     """
     Callback for file upload.
 
@@ -330,7 +330,7 @@ def on_plot_smiles(
     current_stage: int,
     stored_uuid: str,
     file_storage: FileStorage,
-) -> tuple[go.Figure, html.Div, html.Div, html.Div, html.Div, html.Div]:
+) -> Tuple[go.Figure, html.Div, html.Div, html.Div, html.Div, html.Div]:
     """
     Callback for projections visualization stage entry.
     It loads the data from the storage, computes and visualizes the projections.

--- a/dashboard/pages/data_projection/page.py
+++ b/dashboard/pages/data_projection/page.py
@@ -15,7 +15,7 @@ STAGE_NAMES = [
     "Visualization",
     "Save Results",
     "SMILES Input",
-    "Structural Similarity",
+    "Similarity",
 ]
 
 pb.add_stages(STAGES, STAGE_NAMES)

--- a/dashboard/pages/data_projection/page.py
+++ b/dashboard/pages/data_projection/page.py
@@ -14,6 +14,8 @@ STAGE_NAMES = [
     "Files Input",
     "Visualization",
     "Save Results",
+    "SMILES Input",
+    "Structural Similarity",
 ]
 
 pb.add_stages(STAGES, STAGE_NAMES)

--- a/dashboard/pages/data_projection/stages/__init__.py
+++ b/dashboard/pages/data_projection/stages/__init__.py
@@ -1,9 +1,14 @@
 from .s1_projection_input import PROJECTION_INPUT_STAGE
 from .s2_projection_display import PROJECTION_DISPLAY_STAGE
 from .s3_report import REPORT_STAGE
+from .s4_smiles_input import SMILES_INPUT_STAGE
+from .s5_smiles_display import SMILES_PROJECTION_DISPLAY_STAGE
+
 
 STAGES = [
     PROJECTION_INPUT_STAGE,
     PROJECTION_DISPLAY_STAGE,
     REPORT_STAGE,
+    SMILES_INPUT_STAGE,
+    SMILES_PROJECTION_DISPLAY_STAGE,
 ]

--- a/dashboard/pages/data_projection/stages/s4_smiles_input.py
+++ b/dashboard/pages/data_projection/stages/s4_smiles_input.py
@@ -1,14 +1,29 @@
 from dash import html, dcc
 
+
+FILE_PARAMS = [
+    {
+        "id": "upload-activity-data",
+        "title": "Active SMILES",
+        "msg": "Upload file with results from IC50 fitting (with column acitivity_final)",
+    },
+    {
+        "id": "upload-smiles-data",
+        "title": "New SMILES",
+        "msg": "Upload file with untested SMILES to check structural similarity",
+    },
+]
+
+
 FILE_INPUT_CONTAINER = html.Div(
     children=[
         html.Div(
             children=[
                 html.Div(
                     children=[
-                        html.H5("Active SMILES"),
+                        html.H5(param["title"]),
                         html.P(
-                            "Upload file with results from IC50 fitting (with column acitivity_final)",
+                            param["msg"],
                             className="text-justify",
                         ),
                     ],
@@ -16,7 +31,7 @@ FILE_INPUT_CONTAINER = html.Div(
                 html.Div(
                     children=[
                         dcc.Upload(
-                            id="upload-activity-data",
+                            id=param["id"],
                             accept=".csv",
                             children=html.Div(
                                 [
@@ -30,41 +45,11 @@ FILE_INPUT_CONTAINER = html.Div(
                     ],
                     className="upload-box",
                 ),
+                html.Br(),
             ],
             className="grid-2-1",
-        ),
-        html.Br(),
-        html.Div(
-            children=[
-                html.Div(
-                    children=[
-                        html.H5("New SMILES Upload"),
-                        html.P(
-                            "Upload file with untested SMILES to check structural similarity",
-                            className="text-justify",
-                        ),
-                    ],
-                ),
-                html.Div(
-                    children=[
-                        dcc.Upload(
-                            id="upload-smiles-data",
-                            accept=".csv",
-                            children=html.Div(
-                                [
-                                    "Drag and Drop or ",
-                                    html.A("Select File"),
-                                ]
-                            ),
-                            multiple=False,
-                            className="text-center",
-                        ),
-                    ],
-                    className="upload-box",
-                ),
-            ],
-            className="grid-2-1",
-        ),
+        )
+        for param in FILE_PARAMS
     ],
     className="mb-3",
 )

--- a/dashboard/pages/data_projection/stages/s4_smiles_input.py
+++ b/dashboard/pages/data_projection/stages/s4_smiles_input.py
@@ -1,0 +1,81 @@
+from dash import html, dcc
+
+FILE_INPUT_CONTAINER = html.Div(
+    children=[
+        html.Div(
+            children=[
+                html.Div(
+                    children=[
+                        html.H5("Active SMILES"),
+                        html.P(
+                            "Upload file with results from IC50 fitting (with column acitivity_final)",
+                            className="text-justify",
+                        ),
+                    ],
+                ),
+                html.Div(
+                    children=[
+                        dcc.Upload(
+                            id="upload-activity-data",
+                            accept=".csv",
+                            children=html.Div(
+                                [
+                                    "Drag and Drop or ",
+                                    html.A("Select File"),
+                                ]
+                            ),
+                            multiple=False,
+                            className="text-center",
+                        ),
+                    ],
+                    className="upload-box",
+                ),
+            ],
+            className="grid-2-1",
+        ),
+        html.Br(),
+        html.Div(
+            children=[
+                html.Div(
+                    children=[
+                        html.H5("New SMILES Upload"),
+                        html.P(
+                            "Upload file with untested SMILES to check structural similarity",
+                            className="text-justify",
+                        ),
+                    ],
+                ),
+                html.Div(
+                    children=[
+                        dcc.Upload(
+                            id="upload-smiles-data",
+                            accept=".csv",
+                            children=html.Div(
+                                [
+                                    "Drag and Drop or ",
+                                    html.A("Select File"),
+                                ]
+                            ),
+                            multiple=False,
+                            className="text-center",
+                        ),
+                    ],
+                    className="upload-box",
+                ),
+            ],
+            className="grid-2-1",
+        ),
+    ],
+    className="mb-3",
+)
+
+SMILES_INPUT_STAGE = html.Div(
+    id="smiles_input_stage",
+    className="container",
+    children=[
+        FILE_INPUT_CONTAINER,
+        html.Div(
+            id="smiles-file-message",
+        ),
+    ],
+)

--- a/dashboard/pages/data_projection/stages/s5_smiles_display.py
+++ b/dashboard/pages/data_projection/stages/s5_smiles_display.py
@@ -1,0 +1,69 @@
+from dash import dcc, html
+
+SMILES_PROJECTION_DISPLAY_STAGE = html.Div(
+    [
+        html.Div(
+            className="row",
+            children=[
+                html.Div(
+                    [html.H5("Compounds Data")],
+                    className="col-md-6",
+                ),
+                html.Div(
+                    [
+                        html.Div(
+                            className="row",
+                            children=[
+                                html.Div(
+                                    [
+                                        html.Div(
+                                            id="smiles-projection-method-selection-box",
+                                            children=[
+                                                dcc.Dropdown(
+                                                    options={},
+                                                    placeholder="Select a method",
+                                                    disabled=True,
+                                                ),
+                                            ],
+                                        )
+                                    ],
+                                    className="col",
+                                ),
+                            ],
+                        ),
+                    ],
+                    className="col-md-6",
+                ),
+            ],
+        ),
+        html.Div(
+            className="row mt-3",
+            children=[
+                html.Div(
+                    children=[
+                        dcc.Loading(
+                            id="loading-projection-table",
+                            children=[
+                                html.Div(id="smiles-projection-table", children=[])
+                            ],
+                            type="circle",
+                        ),
+                    ],
+                    className="col-md-6",
+                ),
+                html.Div(
+                    children=[
+                        dcc.Loading(
+                            id="loading-projection-plot",
+                            children=[
+                                dcc.Graph(id="smiles-projection-plot", figure={}),
+                            ],
+                            type="circle",
+                        ),
+                    ],
+                    className="col-md-6",
+                ),
+            ],
+        ),
+    ]
+)

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -691,7 +691,7 @@ def plot_clustered_smiles(
         x=projection_x,
         y=projection_y,
         color=feature,
-        color_discrete_sequence=["#00CC96", "#FFA15A", "#636EFA"],
+        color_discrete_sequence=["#009E73", "#F0E442", "#56B4E9"],
         symbol=clusters,
         opacity=0.7,
         labels=labels,

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -1,11 +1,9 @@
 from itertools import product
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-import plotly.tools as tls
 from plotly.subplots import make_subplots
 from rdkit import Chem
 from rdkit.Chem import Draw
@@ -87,8 +85,6 @@ def plot_projection_2d(
             feature: feature_processed,
         },
         title=f"{projection.upper()} projection with respect to {feature_processed}",
-        # width=width,
-        # height=height,
         hover_data={
             "EOS": True,
             projection_x: ":.3f",
@@ -657,3 +653,75 @@ def plot_smiles(smiles_string: str) -> str:
     drawer.FinishDrawing()
     svg = drawer.GetDrawingText().replace("svg:", "")
     return svg
+
+
+def plot_clustered_smiles(
+    df: pd.DataFrame,
+    feature: str = "activity_final",
+    projection: str = "PCA",
+) -> go.Figure:
+    """
+    Plot selected projection and colour points with respect to selected feature.
+
+    :param df: DataFrame to be visualized
+    :param feature: name of the column with respect to which the plot will be coloured
+    :param projection: name of projection to be visualized
+
+    :return: plotly express scatter plot
+    """
+    projection_x = f"{projection.upper()}_0"
+    projection_y = f"{projection.upper()}_1"
+    clusters = f"cluster_{projection}"
+    labels = {
+        projection_x: "X",
+        projection_y: "Y",
+        "EOS": "EOS",
+        feature: "Activity",
+        clusters: "Cluster",
+    }
+    hover_data = {
+        "EOS": True,
+        projection_x: ":.3f",
+        projection_y: ":.3f",
+        feature: True,
+        clusters: True,
+    }
+    fig = px.scatter(
+        df[df[clusters] != "outlier"],
+        x=projection_x,
+        y=projection_y,
+        color=feature,
+        color_discrete_sequence=["#00CC96", "#FFA15A", "#636EFA"],
+        symbol=clusters,
+        opacity=0.7,
+        labels=labels,
+        title=f"{projection.upper()} projection of SMILES with respect to activity",
+        hover_data=hover_data,
+    )
+    fig.add_traces(
+        px.scatter(
+            df[df[clusters] == "outlier"],
+            x=projection_x,
+            y=projection_y,
+            labels=labels,
+            hover_data=hover_data,
+        )
+        .update_traces(
+            marker_color="gray",
+            marker_symbol="x",
+            opacity=0.3,
+            name="outliers",
+            showlegend=True,
+        )
+        .data
+    )
+
+    fig.update_yaxes(title_standoff=15, automargin=True)
+    fig.update_xaxes(title_standoff=30, automargin=True)
+    fig.update_layout(
+        modebar=dict(orientation="v"),
+        margin=dict(r=35, l=15, b=0),
+        title_x=0.5,
+        template=PLOTLY_TEMPLATE,
+    )
+    return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@ scikit-learn
 PyYAML==6.0
 jenkspy
 numpy
-# umap-learn==0.5.3 # removed due to lack of space
-# tensorflow==2.14.0
+umap-learn==0.5.3
 dash
 dash-bootstrap-components
 nbformat>=4.2.0
@@ -18,3 +17,4 @@ rdkit
 pyarrow
 jinja2
 dash_dangerously_set_inner_html
+hdbscan


### PR DESCRIPTION
Added SMILES projections and clustering, the idea is to compare structures of new (untested) compounds with active ones. In that way, one could choose SMILES similar to active compounds and test them (assuming similar to active = active).
![Screenshot from 2023-11-05 19-18-23](https://github.com/zuzg/drug-screening/assets/81712088/3d0c0193-62a7-4a26-a9ed-27e6d4c23b7f)
![Screenshot from 2023-11-05 19-18-54](https://github.com/zuzg/drug-screening/assets/81712088/2bf0c91b-b6ed-4a4a-a8f7-a5ca58a195a3)

TODO
- [x] all the time I get error `TypeError: on_projection_files_upload() got multiple values for argument 'file_storage'` therefore for now the files are loaded locally
- [ ] change legend to two groups (activity and cluster) - not possible if we want working (clickable) legend
- [ ] maybe add possibility to visualize SMILES somewhere? **EDIT** I wonder if it is necessary as user is just one click away from it on ecbd website...
- [x] refactor
- [x] remove outliers
- [x] adjust projection and clustering params