### PR TITLE
closes 159 minor UI adjustments

### DIFF
--- a/dashboard/assets/style.css
+++ b/dashboard/assets/style.css
@@ -208,3 +208,15 @@
 .custom-nav-link.active {
     font-weight: bold;
 }
+
+@media (max-width: 1000px) {
+    main.grid-1-1-1-1 {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 600px) {
+    main.grid-1-1-1-1 {
+        grid-template-columns: repeat(1, 1fr);
+    }
+}

--- a/dashboard/assets/style.css
+++ b/dashboard/assets/style.css
@@ -62,6 +62,10 @@
     min-width: 150px;
 }
 
+.min-w-200px {
+    min-width: 150px;
+}
+
 .min-w-300px {
     min-width: 300px;
 }

--- a/dashboard/assets/style.css
+++ b/dashboard/assets/style.css
@@ -12,6 +12,10 @@
     flex-direction: column;
 }
 
+.mt-n9 {
+    margin-top: -2.25rem !important;
+}
+
 .loading-modal {
     position: fixed;
     top: 0;
@@ -53,6 +57,15 @@
 .min-h-80px {
     min-height: 80px;
 }
+
+.min-w-150px {
+    min-width: 150px;
+}
+
+.min-w-300px {
+    min-width: 300px;
+}
+
 
 .grid-1-1-1-1 {
     display: grid;

--- a/dashboard/pages/about/page.py
+++ b/dashboard/pages/about/page.py
@@ -26,10 +26,10 @@ Finally, by employing the same dataset and parameters, you can consistently achi
 ]
 
 ABOUT_CONTENT = html.Main(
-    className="container-xl h-100 d-flex flex-row mx-5 px-5 mt-5 gap-5",
+    className="container-xl d-block h-100 flex-row mx-5 px-5 mt-5 gap-5 d-lg-flex d-xl-flex d-xxl-flex",
     children=[
         html.Div(
-            className="w-50",
+            className="w-100 w-lg-50 w-xl-50 w-xxl-50",
             children=[
                 html.H2(
                     ABOUT_HEADING,
@@ -64,7 +64,7 @@ ABOUT_CONTENT = html.Main(
             ],
         ),
         html.Div(
-            className="w-50",
+            className="w-100 w-lg-50 w-xl-50 w-xxl-50",
             children=[
                 html.Img(src="/assets/images/flow.svg", className="w-100"),
             ],

--- a/dashboard/pages/components.py
+++ b/dashboard/pages/components.py
@@ -56,11 +56,14 @@ def make_main_header(page_registry: dict):
                     html.Div(
                         className="d-flex flex-wrap align-items-center justify-content-between",
                         children=[
-                            html.Img(
-                                src="/assets/images/logo.svg",
-                                alt="Logo",
-                                className="d-inline-block align-text-top",
-                                height=50,
+                            dcc.Link(
+                                html.Img(
+                                    src="/assets/images/logo.svg",
+                                    alt="Logo",
+                                    className="d-inline-block align-text-top",
+                                    height=50,
+                                ),
+                                href="/",
                             ),
                             html.Nav(
                                 children=[nav_bar],

--- a/dashboard/pages/hit_validation/callbacks.py
+++ b/dashboard/pages/hit_validation/callbacks.py
@@ -217,24 +217,7 @@ def on_hit_browser_stage_entry(
     )
 
     compounds_list = sorted(hit_determination_df["EOS"].unique().tolist())
-    return [
-        html.Button(
-            compound,
-            className="text-center font-monospace fw-semibold mb-1 btn btn-primary btn-sm",
-            id={"type": "compound-button", "index": compound},
-        )
-        for compound in compounds_list
-    ], compounds_list[0]
-
-
-def on_compound_button_click(n_clicks: int, compound_id: str) -> str:
-    """
-    Callback for compound button click. It returns the compound name.
-
-    :param compound: compound name
-    :return: compound name
-    """
-    return callback_context.triggered_id["index"]
+    return compounds_list, compounds_list[0]
 
 
 activity_icons = {
@@ -332,7 +315,6 @@ def on_selected_compound_changed(
     smiles_html = dhtml.DangerouslySetInnerHTML(smiles_graph)
 
     result = {
-        "id": entry["EOS"],
         "min_modulation": round(entry["min_value"], 5),
         "max_modulation": round(entry["max_value"], 5),
         "ic50": round(entry["ic50"], 5),
@@ -368,7 +350,7 @@ def on_selected_compound_changed(
     report_data["is_active_html"] = entry["activity_final"]
     report_data["is_partially_active_html"] = entry["is_partially_active"]
 
-    return tuple(list(result.values()) + [report_data])
+    return list(result.values()) + [report_data]
 
 
 def on_save_individual_EOS_result_button_click(
@@ -455,21 +437,13 @@ def register_callbacks(elements, file_storage: FileStorage):
     )(on_bounds_change)
 
     callback(
-        Output("compounds-list-container", "children"),
-        Output("selected-compound-store", "data"),
+        Output("hit-browser-compound-dropdown", "options"),
+        Output("hit-browser-compound-dropdown", "value"),
         Input(elements["STAGES_STORE"], "data"),
         State("user-uuid", "data"),
     )(functools.partial(on_hit_browser_stage_entry, file_storage=file_storage))
 
     callback(
-        Output("selected-compound-store", "data", allow_duplicate=True),
-        Input({"type": "compound-button", "index": ALL}, "n_clicks"),
-        State({"type": "compound-button", "index": ALL}, "id"),
-        prevent_initial_call=True,
-    )(on_compound_button_click)
-
-    callback(
-        Output("compound-id", "children"),
         Output("min-modulation-value", "children"),
         Output("max-modulation-value", "children"),
         Output("ic50-value", "children"),
@@ -485,7 +459,7 @@ def register_callbacks(elements, file_storage: FileStorage):
         Output("smiles", "children"),
         Output("toxicity", "children"),
         Output("report-data-hit-validation-hit-browser", "data"),
-        Input("selected-compound-store", "data"),
+        Input("hit-browser-compound-dropdown", "value"),
         Input("hit-browser-unstack-button", "n_clicks"),
         Input("hit-browser-apply-button", "n_clicks"),
         State("hit-browser-top", "value"),

--- a/dashboard/pages/hit_validation/callbacks.py
+++ b/dashboard/pages/hit_validation/callbacks.py
@@ -353,10 +353,8 @@ def on_selected_compound_changed(
     return list(result.values()) + [report_data]
 
 
-def on_save_individual_EOS_result_button_click(
-    n_clicks, report_data, file_storage: FileStorage
-):
-    eos = report_data["id"]
+def on_save_individual_EOS_result_button_click(n_clicks, report_data, eos):
+    report_data["id"] = eos
     filename = f"{eos}_report_{datetime.now().strftime('%Y-%m-%d')}.html"
     jinja_template = generate_jinja_report(report_data)
     return dict(content=jinja_template, filename=filename)
@@ -471,12 +469,9 @@ def register_callbacks(elements, file_storage: FileStorage):
         Output("download-EOS-individual-report", "data"),
         Input("save-individual-EOS-result-button", "n_clicks"),
         State("report-data-hit-validation-hit-browser", "data"),
+        State("hit-browser-compound-dropdown", "value"),
         prevent_initial_call=True,
-    )(
-        functools.partial(
-            on_save_individual_EOS_result_button_click, file_storage=file_storage
-        )
-    )
+    )(functools.partial(on_save_individual_EOS_result_button_click))
 
     callback(
         Output("download-json-settings-hit-validation", "data"),

--- a/dashboard/pages/hit_validation/stages/s2_hit_browser.py
+++ b/dashboard/pages/hit_validation/stages/s2_hit_browser.py
@@ -180,30 +180,32 @@ RIGHT_PANEL = html.Div(
                             className="mt-3 d-flex flex-column gap-3",
                             children=[
                                 html.Span(
+                                    className="d-flex flex-row gap-3 align-items-center",
                                     children=[
                                         html.Label(
-                                            "TOP Override:",
-                                            className="form-label",
+                                            "TOP:",
+                                            className="form-label fw-bold w-25",
                                         ),
                                         dcc.Input(
                                             id="hit-browser-top",
                                             type="number",
                                             placeholder="Top",
-                                            className="form-control",
+                                            className="form-control w-75",
                                         ),
                                     ],
                                 ),
                                 html.Span(
+                                    className="d-flex flex-row gap-3 align-items-center",
                                     children=[
                                         html.Label(
-                                            "BOTTOM Override:",
-                                            className="form-label",
+                                            "BOTTOM:",
+                                            className="form-label fw-bold w-25",
                                         ),
                                         dcc.Input(
                                             id="hit-browser-bottom",
                                             type="number",
                                             placeholder="Bottom",
-                                            className="form-control",
+                                            className="form-control w-75",
                                         ),
                                     ],
                                 ),
@@ -212,12 +214,12 @@ RIGHT_PANEL = html.Div(
                                     children=[
                                         html.Button(
                                             id="hit-browser-apply-button",
-                                            className="btn btn-primary flex-grow-1",
+                                            className="btn btn-primary w-50",
                                             children="Apply Stacking",
                                         ),
                                         html.Button(
                                             id="hit-browser-unstack-button",
-                                            className="btn btn-primary flex-grow-1",
+                                            className="btn btn-secondary w-50",
                                             children="Unstack",
                                         ),
                                     ],

--- a/dashboard/pages/hit_validation/stages/s2_hit_browser.py
+++ b/dashboard/pages/hit_validation/stages/s2_hit_browser.py
@@ -2,17 +2,6 @@ from dash import html, dcc
 import dash_bootstrap_components as dbc
 
 
-LEFT_PANEL = html.Div(
-    children=[
-        html.P("All Compounds", className="fw-bold mb-3"),
-        html.Div(
-            className="h-100 d-flex flex-column panel-restricted",
-            id="compounds-list-container",
-        ),
-    ],
-    className="border-end border-2 px-3 d-flex flex-column h-100 min-w-150px",
-)
-
 PARAMS_DISPLAY_SPEC = [
     {
         "label": "Min Modulation",
@@ -120,14 +109,26 @@ SMILES_TAB = dbc.Tab(
     ],
 )
 
-RIGHT_PANEL = html.Div(
+MAIN_PANEL = html.Div(
     id="hit-browser-container",
     children=[
         html.Header(
             className="d-flex flex-row justify-content-between align-items-center",
             children=[
-                html.H5("Compound ID", className="fw-bold mb-0", id="compound-id"),
-                html.Div(
+                html.Span(
+                    className="d-flex flex-row gap-3 align-items-center",
+                    children=[
+                        html.H5("Compound:", className="mb-0"),
+                        dcc.Dropdown(
+                            id="hit-browser-compound-dropdown",
+                            placeholder="Select Compound",
+                            clearable=False,
+                            searchable=True,
+                            className="fw-bold min-w-200px",
+                        ),
+                    ],
+                ),
+                html.Span(
                     className="d-flex flex-row gap-3",
                     children=[
                         html.Button(
@@ -236,9 +237,7 @@ RIGHT_PANEL = html.Div(
 
 HIT_BROWSER_STAGE = html.Div(
     children=[
-        LEFT_PANEL,
-        RIGHT_PANEL,
-        dcc.Store(id="selected-compound-store", data=None),
+        MAIN_PANEL,
     ],
     className="d-flex flex-row gap-3 h-100",
 )

--- a/dashboard/pages/hit_validation/stages/s2_hit_browser.py
+++ b/dashboard/pages/hit_validation/stages/s2_hit_browser.py
@@ -1,4 +1,5 @@
 from dash import html, dcc
+import dash_bootstrap_components as dbc
 
 
 LEFT_PANEL = html.Div(
@@ -9,7 +10,7 @@ LEFT_PANEL = html.Div(
             id="compounds-list-container",
         ),
     ],
-    className="border-end border-2 px-3 d-flex flex-column h-100",
+    className="border-end border-2 px-3 d-flex flex-column h-100 min-w-150px",
 )
 
 PARAMS_DISPLAY_SPEC = [
@@ -59,15 +60,39 @@ PARAMS_DISPLAY_SPEC = [
         "units": "",
     },
 ]
-BOTTOM_PANEL = html.Section(
-    className="row",
+
+GRAPH_TAB = dbc.Tab(
+    label="Graph",
+    tab_id="graph-tab",
+    tabClassName="ms-auto",
     children=[
-        html.H5("Toxicity prediction based on SMILES"),
         html.Div(
-            className="row",
+            className="d-flex flex-column h-100",
+            children=[
+                dcc.Graph(
+                    id="hit-browser-plot",
+                    figure={},
+                    config={
+                        "displayModeBar": False,
+                        "scrollZoom": False,
+                    },
+                    responsive=True,
+                )
+            ],
+        ),
+    ],
+)
+
+SMILES_TAB = dbc.Tab(
+    label="SMILES",
+    tab_id="smiles-tab",
+    children=[
+        html.P("Compound Structure", className="fw-bold mt-3"),
+        html.Div(
             children=[
                 html.Div(
                     id="smiles",
+                    className="d-flex flex-row justify-content-center",
                 ),
                 html.Div(
                     children=[
@@ -98,28 +123,34 @@ BOTTOM_PANEL = html.Section(
 RIGHT_PANEL = html.Div(
     id="hit-browser-container",
     children=[
-        html.H5("Compound ID", className="fw-bold mb-3", id="compound-id"),
+        html.Header(
+            className="d-flex flex-row justify-content-between align-items-center",
+            children=[
+                html.H5("Compound ID", className="fw-bold mb-0", id="compound-id"),
+                html.Div(
+                    className="d-flex flex-row gap-3",
+                    children=[
+                        html.Button(
+                            id="save-individual-EOS-result-button",
+                            className="btn btn-primary",
+                            children="Save HTML Report",
+                        ),
+                        dcc.Download(id="download-EOS-individual-report"),
+                    ],
+                ),
+            ],
+        ),
         html.Div(
             className="d-flex flex-row justify-content-between h-100",
             children=[
                 html.Div(
-                    className="d-flex flex-column h-100",
-                    style={"width": "700px"},
-                    children=[
-                        dcc.Graph(
-                            id="hit-browser-plot",
-                            figure={},
-                            config={
-                                "displayModeBar": False,
-                                "scrollZoom": False,
-                            },
-                            style={"max-width": "700px"},
-                            responsive=True,
-                        )
-                    ],
+                    className="me-5 mt-n9 h-100 flex-grow-1",
+                    children=dbc.Tabs(
+                        [GRAPH_TAB, SMILES_TAB],
+                    ),
                 ),
                 html.Div(
-                    className="d-flex flex-column h-100 flex-grow-1",
+                    className="d-flex flex-column h-100 mt-3 min-w-300px",
                     children=[
                         html.Section(
                             children=[
@@ -146,7 +177,7 @@ RIGHT_PANEL = html.Div(
                             ]
                         ),
                         html.Section(
-                            className="mt-5 d-flex flex-column gap-3",
+                            className="mt-3 d-flex flex-column gap-3",
                             children=[
                                 html.Span(
                                     children=[
@@ -191,22 +222,8 @@ RIGHT_PANEL = html.Div(
                                         ),
                                     ],
                                 ),
-                                html.Span(
-                                    className="d-flex flex-row gap-3 w-100",
-                                    children=[
-                                        html.Button(
-                                            id="save-individual-EOS-result-button",
-                                            className="btn btn-primary flex-grow-1",
-                                            children="Save result",
-                                        ),
-                                        dcc.Download(
-                                            id="download-EOS-individual-report"
-                                        ),
-                                    ],
-                                ),
                             ],
                         ),
-                        BOTTOM_PANEL,
                     ],
                 ),
             ],

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -623,7 +623,6 @@ def plot_ic50(entry: dict, x: np.ndarray, y: np.ndarray) -> go.Figure:
         )
 
     return go.Figure(
-        layout_title_text="IC50",
         layout={
             "xaxis": {
                 "title": "Concentration [uM]",
@@ -636,6 +635,12 @@ def plot_ic50(entry: dict, x: np.ndarray, y: np.ndarray) -> go.Figure:
                 "visible": True,
                 "showticklabels": True,
             },
+            "margin": dict(
+                l=10,
+                r=10,
+                t=50,
+                b=10,
+            ),
         },
         data=data,
     )


### PR DESCRIPTION
## 1. I added responsiveness to home and about pages:

Home page - two breakpoints folding to 2 columns and then to 1 column:
<img width="433" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/74a6e4fe-995d-4ec3-b471-218223cb42d7">
<img width="271" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/36aac8da-363c-4eac-892c-9ba243faf65c">

About page - one breakpoint folding to 1 column:
<img width="329" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/aa4ed99a-d9e7-47d3-a0fd-5d6dc07e6bd7">

## 2. I added link to the logo that redirects to Home page on click
## 3 I redesigned UI of the Hit Browser stage, introduced searchbox instead of list of buttons

Entire Left panel with buttons is removed, I put search box in the header. Toxicity/SMILES visualization together with the IC50 Graph moved to a common TabView with distinct Tabs

Rearranged buttons and Stacking inputs:
<img width="1080" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/6a59dce0-8ce2-400b-b34e-0d10c59055a8">
<img width="1080" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/2cceac4b-9c7e-4abb-b848-9c5ae8fd0b85">
