### PR TITLE
closes 165 update projections

### DIFF
--- a/dashboard/data/preprocess.py
+++ b/dashboard/data/preprocess.py
@@ -122,9 +122,9 @@ class MergedAssaysPreprocessor:
         X_controls = self.controls_df[self.columns_for_projection].to_numpy()
         X_projected_controls = projector.transform(X_controls)
 
-        suffixes = ["X", "Y"]
+        suffixes = ["X", "Y", "Z"]
 
-        if X_projected.shape[1] > 2:
+        if X_projected.shape[1] > len(suffixes):
             # if more than 2 projected dimensions, use numbers as suffixes
             suffixes = range(X_projected.shape[0])
 

--- a/dashboard/data/structural_similarity.py
+++ b/dashboard/data/structural_similarity.py
@@ -60,17 +60,18 @@ def merge_active_new(
     return merged
 
 
-def calculate_umap(descriptors: np.ndarray) -> np.ndarray:
+def calculate_umap(descriptors: np.ndarray, n_components: int = 2) -> np.ndarray:
     """
     Calculate UMAP projection
 
     :param descriptors: descriptors
+    :param n_components: number of components to project to
     :return: array with projection
     """
     umap_model = umap.UMAP(
         metric="jaccard",
         n_neighbors=25,
-        n_components=2,
+        n_components=n_components,
         low_memory=False,
         min_dist=0.001,
     )
@@ -78,14 +79,15 @@ def calculate_umap(descriptors: np.ndarray) -> np.ndarray:
     return X_umap
 
 
-def calculate_pca(descriptors: np.ndarray) -> np.ndarray:
+def calculate_pca(descriptors: np.ndarray, n_components: int = 2) -> np.ndarray:
     """
     Calculate PCA projection
 
     :param descriptors: descriptors
+    :param n_components: number of components to project to
     :return: array with projection
     """
-    pca_model = PCA(n_components=2)
+    pca_model = PCA(n_components=n_components)
     X_pca = pca_model.fit_transform(descriptors)
     return X_pca
 
@@ -120,9 +122,18 @@ def prepare_cluster_viz(
     ecfp_descriptors, keep_idx = compute_ecfp_descriptors(df["smiles"])
     df = df.iloc[keep_idx]
     X_umap = calculate_umap(ecfp_descriptors)
-    df["UMAP_0"], df["UMAP_1"] = X_umap[:, 0], X_umap[:, 1]
+    df["UMAP_X"], df["UMAP_Y"] = X_umap[:, 0], X_umap[:, 1]
     df["cluster_UMAP"] = calculate_clusters(X_umap)
-    X_pca = calculate_pca(ecfp_descriptors)
-    df["PCA_0"], df["PCA_1"] = X_pca[:, 0], X_pca[:, 1]
+
+    X_umap_3d = calculate_umap(ecfp_descriptors, n_components=3)
+    df["UMAP3D_X"], df["UMAP3D_Y"], df["UMAP3D_Z"] = (
+        X_umap_3d[:, 0],
+        X_umap_3d[:, 1],
+        X_umap_3d[:, 2],
+    )
+    df["cluster_UMAP3D"] = calculate_clusters(X_umap_3d)
+
+    X_pca = calculate_pca(ecfp_descriptors, 3)
+    df["PCA_X"], df["PCA_Y"], df["PCA_Z"] = X_pca[:, 0], X_pca[:, 1], X_pca[:, 2]
     df["cluster_PCA"] = calculate_clusters(X_pca)
     return df

--- a/dashboard/pages/data_projection/callbacks.py
+++ b/dashboard/pages/data_projection/callbacks.py
@@ -266,6 +266,17 @@ def on_projection_download_selection_button_click(
     return dcc.send_data_frame(selected_subset_df.to_csv, filename)
 
 
+def on_3d_checkbox_change(plot_3d: List[str]) -> bool:
+    """
+    Callback for the 3d checkbox change. Disables the download selection button if 3d is selected.
+
+
+    :param plot_3d: 3d checkbox selection
+    :return: boolean indicating if the button should be disabled
+    """
+    return bool(plot_3d)
+
+
 # === STAGE 3 ===
 
 
@@ -463,6 +474,10 @@ def register_callbacks(elements, file_storage: FileStorage):
         )
     )
     callback(
+        Output("projection-download-selection-button", "disabled"),
+        Input("3d-checkbox", "value"),
+    )(on_3d_checkbox_change)
+    callback(
         Output("download-projections-csv", "data"),
         Input("save-projections-button", "n_clicks"),
         State("user-uuid", "data"),
@@ -510,3 +525,7 @@ def register_callbacks(elements, file_storage: FileStorage):
             on_smiles_download_selection_button_click, file_storage=file_storage
         )
     )
+    callback(
+        Output("smiles-download-selection-button", "disabled"),
+        Input("3d-checkbox-smiles", "value"),
+    )(on_3d_checkbox_change)

--- a/dashboard/pages/data_projection/callbacks.py
+++ b/dashboard/pages/data_projection/callbacks.py
@@ -167,52 +167,10 @@ def on_projections_visualization_entry(
         ]
     )
 
-    method_options = html.Div(
-        children=[
-            dcc.Dropdown(
-                id="projection-method-selection-box",
-                options=[
-                    {"label": "UMAP", "value": "UMAP"},
-                    {"label": "PCA", "value": "PCA"},
-                ],
-                value="PCA",
-                searchable=False,
-                clearable=False,
-                disabled=False,
-            ),
-        ]
-    )
-
-    checkboxes = html.Div(
-        className="d-flex flex-row gap-3",
-        children=[
-            dcc.Checklist(
-                options=[
-                    {
-                        "label": "  Show control values",
-                        "value": "controls",
-                    }
-                ],
-                value=[],
-                id="control-checkbox",
-            ),
-            dcc.Checklist(
-                options=[
-                    {
-                        "label": "  Plot 3D",
-                        "value": "3d",
-                    }
-                ],
-                value=[],
-                id="3d-checkbox",
-            ),
-        ],
-    )
-
     pca = PROJECTION_SETUP[0][0]
     projection_info = pca_summary(pca, projection_columns)
 
-    return (fig, table, attribute_options, method_options, projection_info, checkboxes)
+    return fig, table, attribute_options, projection_info
 
 
 def on_checkbox_change(
@@ -251,7 +209,7 @@ def on_checkbox_change(
     )
 
 
-def on_plot_selected_data(
+def on_plot_zommed_in(
     relayout_data: dict,
     stored_uuid: str,
     projection_type: str,
@@ -281,6 +239,33 @@ def on_plot_selected_data(
     return eos_to_ecbd_link(df).to_dict("records")
 
 
+def on_projection_download_selection_button_click(
+    n_clicks: int,
+    selection: dict,
+    stored_uuid: str,
+    file_storage: FileStorage,
+) -> dict:
+    """
+    Callback for the download selected button click. Downloads lasso/box selected datapoints
+    to a csv file.
+
+    :param n_clicks: number of clicks
+    :param stored_uuid: session uuid
+    :param file_storage: storage object
+    """
+    if not selection:
+        return no_update
+
+    datapoints = [point["pointIndex"] for point in selection["points"]]
+
+    df = pd.read_parquet(
+        pa.BufferReader(file_storage.read_file(f"{stored_uuid}_assays_projection.pq")),
+    )
+    selected_subset_df = df.iloc[datapoints]
+    filename = f"projection_data_{datetime.now().strftime('%Y-%m-%d')}-selection-{selected_subset_df.shape[0]}.csv"
+    return dcc.send_data_frame(selected_subset_df.to_csv, filename)
+
+
 # === STAGE 3 ===
 
 
@@ -288,7 +273,7 @@ def on_save_projections_click(
     n_clicks: int,
     stored_uuid: str,
     file_storage: FileStorage,
-) -> None:
+) -> dict:
     """
     Callback for the save projections button
 
@@ -425,9 +410,7 @@ def register_callbacks(elements, file_storage: FileStorage):
         Output("projection-plot", "figure", allow_duplicate=True),
         Output("projection-table", "children"),
         Output("projection-attribute-selection-box", "children"),
-        Output("projection-method-selection-box", "children"),
         Output("pca-info", "children"),
-        Output("control-checkbox", "children"),
         Input(elements["STAGES_STORE"], "data"),
         State("user-uuid", "data"),
         prevent_initial_call=True,
@@ -442,6 +425,17 @@ def register_callbacks(elements, file_storage: FileStorage):
         prevent_initial_call=True,
     )(functools.partial(on_checkbox_change, file_storage=file_storage))
     callback(
+        Output("projection-download-selection-csv", "data"),
+        Input("projection-download-selection-button", "n_clicks"),
+        State("projection-plot", "selectedData"),
+        State("user-uuid", "data"),
+        prevent_initial_call=True,
+    )(
+        functools.partial(
+            on_projection_download_selection_button_click, file_storage=file_storage
+        )
+    )
+    callback(
         Output("download-projections-csv", "data"),
         Input("save-projections-button", "n_clicks"),
         State("user-uuid", "data"),
@@ -453,7 +447,7 @@ def register_callbacks(elements, file_storage: FileStorage):
         State("user-uuid", "data"),
         State("projection-method-selection-box", "value"),
         prevent_initial_call=True,
-    )(functools.partial(on_plot_selected_data, file_storage=file_storage))
+    )(functools.partial(on_plot_zommed_in, file_storage=file_storage))
     callback(
         Output("smiles-file-message", "children"),
         Input("upload-activity-data", "contents"),

--- a/dashboard/pages/data_projection/stages/s2_projection_display.py
+++ b/dashboard/pages/data_projection/stages/s2_projection_display.py
@@ -20,9 +20,21 @@ PROJECTION_DISPLAY_STAGE = html.Div(
                                             id="projection-method-selection-box",
                                             children=[
                                                 dcc.Dropdown(
-                                                    options={},
-                                                    placeholder="Select a method",
-                                                    disabled=True,
+                                                    id="projection-method-selection-box",
+                                                    options=[
+                                                        {
+                                                            "label": "UMAP",
+                                                            "value": "UMAP",
+                                                        },
+                                                        {
+                                                            "label": "PCA",
+                                                            "value": "PCA",
+                                                        },
+                                                    ],
+                                                    value="PCA",
+                                                    searchable=False,
+                                                    clearable=False,
+                                                    disabled=False,
                                                 ),
                                             ],
                                         )
@@ -88,7 +100,48 @@ PROJECTION_DISPLAY_STAGE = html.Div(
                     className="col-md-6",
                 ),
                 html.Div(
-                    children=[html.Div(id="control-checkbox", children=[])],
+                    children=[
+                        html.Div(
+                            className="d-flex flex-row justify-content-between",
+                            children=[
+                                html.Span(
+                                    className="d-flex flex-row align-items-center gap-3",
+                                    children=[
+                                        dcc.Checklist(
+                                            options=[
+                                                {
+                                                    "label": "  Show control values",
+                                                    "value": "controls",
+                                                }
+                                            ],
+                                            value=[],
+                                            id="control-checkbox",
+                                        ),
+                                        dcc.Checklist(
+                                            options=[
+                                                {
+                                                    "label": "  Plot 3D",
+                                                    "value": "3d",
+                                                }
+                                            ],
+                                            value=[],
+                                            id="3d-checkbox",
+                                        ),
+                                    ],
+                                ),
+                                html.Button(
+                                    children=[
+                                        "Download Selected",
+                                        dcc.Download(
+                                            id="projection-download-selection-csv"
+                                        ),
+                                    ],
+                                    id="projection-download-selection-button",
+                                    className="btn btn-primary",
+                                ),
+                            ],
+                        )
+                    ],
                     className="col-md-6",
                 ),
             ],

--- a/dashboard/pages/data_projection/stages/s5_smiles_display.py
+++ b/dashboard/pages/data_projection/stages/s5_smiles_display.py
@@ -4,6 +4,14 @@ CONTROLS = (
     html.Div(
         className="d-flex flex-row gap-3 align-items-center w-100",
         children=[
+            html.Button(
+                children=[
+                    "Download Selected",
+                    dcc.Download(id="smiles-download-selection-csv"),
+                ],
+                id="smiles-download-selection-button",
+                className="btn btn-primary",
+            ),
             dcc.Dropdown(
                 className="min-w-150px",
                 id="smiles-projection-method-selection-box",

--- a/dashboard/pages/data_projection/stages/s5_smiles_display.py
+++ b/dashboard/pages/data_projection/stages/s5_smiles_display.py
@@ -1,5 +1,41 @@
 from dash import dcc, html
 
+CONTROLS = (
+    html.Div(
+        className="d-flex flex-row gap-3 align-items-center w-100",
+        children=[
+            dcc.Dropdown(
+                className="min-w-150px",
+                id="smiles-projection-method-selection-box",
+                options=[
+                    {
+                        "label": "UMAP",
+                        "value": "UMAP",
+                    },
+                    {
+                        "label": "PCA",
+                        "value": "PCA",
+                    },
+                ],
+                value="PCA",
+                searchable=False,
+                clearable=False,
+                disabled=False,
+            ),
+            dcc.Checklist(
+                options=[
+                    {
+                        "label": "  Plot 3D",
+                        "value": "3d",
+                    }
+                ],
+                value=[],
+                id="3d-checkbox-smiles",
+            ),
+        ],
+    ),
+)
+
 SMILES_PROJECTION_DISPLAY_STAGE = html.Div(
     [
         html.Div(
@@ -10,28 +46,7 @@ SMILES_PROJECTION_DISPLAY_STAGE = html.Div(
                     className="col-md-6",
                 ),
                 html.Div(
-                    [
-                        html.Div(
-                            className="row",
-                            children=[
-                                html.Div(
-                                    [
-                                        html.Div(
-                                            id="smiles-projection-method-selection-box",
-                                            children=[
-                                                dcc.Dropdown(
-                                                    options={},
-                                                    placeholder="Select a method",
-                                                    disabled=True,
-                                                ),
-                                            ],
-                                        )
-                                    ],
-                                    className="col",
-                                ),
-                            ],
-                        ),
-                    ],
+                    CONTROLS,
                     className="col-md-6",
                 ),
             ],

--- a/dashboard/visualization/overlay.py
+++ b/dashboard/visualization/overlay.py
@@ -7,6 +7,7 @@ def projection_plot_overlay_controls(
     controls_df: pd.DataFrame,
     style_dict: dict[str, list[str, int]],
     projection: str = "pca",
+    plot_3d: bool = False,
 ) -> go.Figure:
     """
     Add control values to the plot of selected projection.
@@ -15,31 +16,41 @@ def projection_plot_overlay_controls(
     :param controls_df: dataframe with control values
     :param style_dict: dictionary with styles (color and font size) for each annotation
     :param projection: name of projection to be visualized
-    :param cvd: whether the plot is for CVD or not
+    :param plot_3d: if True, plot 3D projection
     :return: plotly express scatter plot with control values
     """
     fig_controls = go.Figure(fig)
     fig_controls.update_traces(marker={"opacity": 0.6})
-
+    overlay_func = fig_controls.add_scatter
+    if plot_3d:
+        overlay_func = fig_controls.add_scatter3d
     for name, group in controls_df.groupby("annotation"):
         if name not in style_dict:
             continue
         color, size = style_dict[name]
-        fig_controls.add_scatter(
+        extra_arg = dict()
+        hovertemplate = (
+            "<b> %{text[0]}</b><br>"
+            + "<b>%{text[1]}</b><br>"
+            + "X: %{x:.4f}<br>Y: %{y:.4f}<br>"
+        )
+        if plot_3d:
+            extra_arg["z"] = group[f"{projection.upper()}_Z"]
+            hovertemplate += "Z: %{z:.4f}<br>"
+        hovertemplate += "<extra></extra>"
+        overlay_func(
             x=group[f"{projection.upper()}_X"],
             y=group[f"{projection.upper()}_Y"],
             mode="markers",
             marker=dict(
                 size=size,
                 color=color,
-                symbol="star-diamond",
+                symbol="diamond",
             ),
             name=str.upper(name).replace("_", " "),
             text=group["EOS"].str.split(";"),
-            hovertemplate="<b> %{text[0]}</b><br>"
-            + "<b>%{text[1]}</b><br>"
-            + "X: %{x:.4f}<br>Y: %{y:.4f}<br>"
-            + "<extra></extra>",
+            hovertemplate=hovertemplate,
+            **extra_arg,
         )
 
     fig_controls.update_layout(

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -16,44 +16,6 @@ from dashboard.visualization.overlay import projection_plot_overlay_controls
 PLOTLY_TEMPLATE = "plotly_white"
 
 
-def make_projection_plot(
-    projection_df: pd.DataFrame,
-    controls_df: pd.DataFrame,
-    colormap_feature: str,
-    projection_type: str,
-    checkbox_values: list[str],
-) -> go.Figure:
-    """
-    Construct a scatterplot from a dataframe.
-
-    :param projection_df: dataframe to construct plot from
-    :param colormap_feature: feature to use for coloring
-    :param projection_type: projection type
-    :param checkbox_values: list of checkbox values
-    :return: dcc Graph element containing the plot
-    """
-    figure = plot_projection_2d(
-        projection_df,
-        colormap_feature,
-        projection=projection_type,
-    )
-    if checkbox_values and "controls" in checkbox_values:
-        default_style = {
-            "ALL NEGATIVE": ["#de425b", 12],
-            "ALL POSITIVE": ["#488f31", 12],
-            "ALL BUT ONE NEGATIVE": ["#eb7a52", 10],
-            "ALL BUT ONE POSITIVE": ["#8aac49", 10],
-        }
-
-        figure = projection_plot_overlay_controls(
-            figure,
-            controls_df,
-            default_style,
-            projection=projection_type,
-        )
-    return figure
-
-
 def plot_projection_2d(
     df: pd.DataFrame,
     feature: str,
@@ -104,6 +66,113 @@ def plot_projection_2d(
         template=PLOTLY_TEMPLATE,
     )
     return fig
+
+
+def plot_projection_3d(
+    df: pd.DataFrame,
+    feature: str,
+    projection: str = "pca",
+) -> go.Figure:
+    """
+    Plot selected projection and colour points with respect to selected feature in 3D.
+    Expects dataframe has projection features X, Y and Z.
+
+    :param df: DataFrame to be visualized
+    :param feature: name of the column with respect to which the plot will be coloured
+    :param projection: type of the projection, defaults to "pca"
+    :return: plotly express 3d scatter plot
+    """
+    projection_x = f"{projection.upper()}_X"
+    projection_y = f"{projection.upper()}_Y"
+    projection_z = f"{projection.upper()}_Z"
+    feature_processed = feature.replace("_", " ").upper()
+    fig = px.scatter_3d(
+        df,
+        x=projection_x,
+        y=projection_y,
+        z=projection_z,
+        color=df[feature],
+        range_color=[0, df[feature].max()],
+        labels={
+            projection_x: "X",
+            projection_y: "Y",
+            projection_z: "Z",
+            "EOS": "ID",
+            feature: feature_processed,
+        },
+        title=f"{projection.upper()} projection with respect to {feature_processed}",
+        hover_data={
+            "EOS": True,
+            projection_x: ":.3f",
+            projection_y: ":.3f",
+            projection_z: ":.3f",
+            feature: ":.3f",
+        },
+    )
+
+    fig.update_traces(marker={"size": 8})
+    fig.update_yaxes(title_standoff=15, automargin=True)
+    fig.update_xaxes(title_standoff=30, automargin=True)
+    fig.update_layout(
+        modebar=dict(orientation="v"),
+        margin=dict(r=35, l=15, b=0),
+        title_x=0.5,
+        coloraxis_colorbar=dict(orientation="h", thickness=15),
+        template=PLOTLY_TEMPLATE,
+    )
+    return fig
+
+
+def make_projection_plot(
+    projection_df: pd.DataFrame,
+    controls_df: pd.DataFrame,
+    colormap_feature: str,
+    projection_type: str,
+    show_controls: bool = False,
+    plot_3d: bool = False,
+) -> go.Figure:
+    """
+    Construct a scatterplot from a dataframe.
+
+    :param projection_df: dataframe to construct plot from
+    :param colormap_feature: feature to use for coloring
+    :param projection_type: projection type
+    :param show_controls: whether to show controls
+    :param plot_3d: whether to plot in 3d
+    :return: dcc Graph element containing the plot
+    """
+    if projection_type.lower() not in ["pca", "umap"]:
+        raise ValueError(
+            f"Projection type {projection_type} not supported. "
+            f"Supported types: 'pca', 'umap'."
+        )
+
+    if projection_type.lower() == "umap" and plot_3d:
+        projection_type = "umap3d"
+
+    plotting_function = plot_projection_3d if plot_3d else plot_projection_2d
+    figure = plotting_function(
+        projection_df,
+        colormap_feature,
+        projection=projection_type,
+    )
+
+    if show_controls:
+        default_style = {
+            "ALL NEGATIVE": ["#de425b", 12],
+            "ALL POSITIVE": ["#488f31", 12],
+            "ALL BUT ONE NEGATIVE": ["#eb7a52", 10],
+            "ALL BUT ONE POSITIVE": ["#8aac49", 10],
+        }
+
+        figure = projection_plot_overlay_controls(
+            figure,
+            controls_df,
+            default_style,
+            projection=projection_type,
+            plot_3d=plot_3d,
+        )
+    return figure
 
 
 def visualize_multiple_plates(
@@ -664,6 +733,7 @@ def plot_clustered_smiles(
     df: pd.DataFrame,
     feature: str = "activity_final",
     projection: str = "PCA",
+    plot_3d: bool = False,
 ) -> go.Figure:
     """
     Plot selected projection and colour points with respect to selected feature.
@@ -671,12 +741,22 @@ def plot_clustered_smiles(
     :param df: DataFrame to be visualized
     :param feature: name of the column with respect to which the plot will be coloured
     :param projection: name of projection to be visualized
+    :param plot_3d: if True, plot 3D projection
 
     :return: plotly express scatter plot
     """
-    projection_x = f"{projection.upper()}_0"
-    projection_y = f"{projection.upper()}_1"
-    clusters = f"cluster_{projection}"
+    if projection.lower() not in ["pca", "umap"]:
+        raise ValueError(
+            f"Projection type {projection} not supported. "
+            f"Supported types: 'pca', 'umap'."
+        )
+
+    if projection.lower() == "umap" and plot_3d:
+        projection = "umap3d"
+
+    projection_x = f"{projection.upper()}_X"
+    projection_y = f"{projection.upper()}_Y"
+    clusters = f"cluster_{projection.upper()}"
     labels = {
         projection_x: "X",
         projection_y: "Y",
@@ -691,7 +771,16 @@ def plot_clustered_smiles(
         feature: True,
         clusters: True,
     }
-    fig = px.scatter(
+    extra_args = {}
+    plot_func = px.scatter
+    if plot_3d:
+        projection_z = f"{projection.upper()}_Z"
+        labels[projection_z] = "Z"
+        hover_data[projection_z] = ":.3f"
+        extra_args["z"] = projection_z
+        plot_func = px.scatter_3d
+
+    fig = plot_func(
         df[df[clusters] != "outlier"],
         x=projection_x,
         y=projection_y,
@@ -702,14 +791,16 @@ def plot_clustered_smiles(
         labels=labels,
         title=f"{projection.upper()} projection of SMILES with respect to activity",
         hover_data=hover_data,
+        **extra_args,
     )
     fig.add_traces(
-        px.scatter(
+        plot_func(
             df[df[clusters] == "outlier"],
             x=projection_x,
             y=projection_y,
             labels=labels,
             hover_data=hover_data,
+            **extra_args,
         )
         .update_traces(
             marker_color="gray",


### PR DESCRIPTION
Added 3D Plotting and selection csv report download for **Data Projection** process for _Visualization_ and _Similarity_ stages.

As a bonus - I readded UMAP for _Visualization_ stage

3D plots for _Visualization_ can also show control values

by default plots are 2d.

Note that 3d plots do not support zooming/selecting datapoints

To export selection, enter box/lasso selection mode, select interesting datapoints and press `Download Selected` button:
<img width="1062" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/7f5ea792-b56a-433f-9d49-a1e24f95f994">

Resulting file:
[projection_data_2023-11-17-selection-30.csv](https://github.com/zuzg/drug-screening/files/13397264/projection_data_2023-11-17-selection-30.csv)

**Visualization 3d plots**:
<img width="1063" alt="visualization-umap-3d" src="https://github.com/zuzg/drug-screening/assets/72276326/b4e2069e-7280-437a-aa2c-1d62ea4894e7">
<img width="1061" alt="visualization-pca-3d" src="https://github.com/zuzg/drug-screening/assets/72276326/b178491b-971d-4ad4-bae1-ebc59c0663b5">

**Similarity 3d plots**:
<img width="1068" alt="similarity-pca-3d" src="https://github.com/zuzg/drug-screening/assets/72276326/810a3bc8-e2ad-41b3-a459-460e9788ffaa">
<img width="1061" alt="similarity-umap-3d" src="https://github.com/zuzg/drug-screening/assets/72276326/e14f2210-e65a-4e3f-adbb-d8ad541f7f4c">
