### PR TITLE
closes 182 screening process adjustments

### DIFF
--- a/dashboard/data/bmg_plate.py
+++ b/dashboard/data/bmg_plate.py
@@ -1,9 +1,11 @@
 import io
 import numpy as np
 import pandas as pd
-from collections import namedtuple
-from enum import Enum, auto
+import logging
 
+from collections import namedtuple
+
+logger = logging.getLogger(__name__)
 
 PlateSummary = namedtuple(
     "PlateSummary",
@@ -159,30 +161,46 @@ def parse_bmg_file(filename: str, filecontent: io.StringIO) -> np.ndarray:
             df = pd.read_csv(filecontent, header=None)
             plate = df.to_numpy()
             break
-        well, value = line.split()
+        if not line.strip():
+            continue
+        cells = line.split()
+        if len(cells) != 2:
+            raise ValueError(
+                f"Wrong format of file {filename} - line {i} has {len(cells)} cells instead of 2"
+            )
+        well, value = cells
         i, j = well_to_ids(well)
         plate[i, j] = value
     return barcode, plate
 
 
-def parse_bmg_files(files: tuple[str, io.StringIO]) -> tuple[pd.DataFrame, np.ndarray]:
+def parse_bmg_files(
+    files: tuple[str, io.StringIO]
+) -> tuple[pd.DataFrame, np.ndarray, dict[str, str]]:
     """
     Parse file from iostring with BMG files to DataFrame
 
     :param files: tuple containing names and content of files
-    :return: DataFrame with BMG files (=plates) as rows
+    :param failed_files: dictionary with failed files
+    :return: DataFrame with BMG files (=plates) as rows,
+        plates values as np.array and failed files with errors
     """
     plate_summaries = []
     plate_values = []
+    failed_files = {}
     for filename, filecontent in files:
-        barcode, plate_array = parse_bmg_file(filename, filecontent)
-        plate = Plate(barcode, plate_array)
-        z_wo, outliers_mask = calculate_z_outliers(plate)
-        plate_summaries.append(get_summary_tuple(plate, z_wo))
-        plate_values.append([plate.plate_array, outliers_mask])
+        try:
+            barcode, plate_array = parse_bmg_file(filename, filecontent)
+            plate = Plate(barcode, plate_array)
+            z_wo, outliers_mask = calculate_z_outliers(plate)
+            plate_summaries.append(get_summary_tuple(plate, z_wo))
+            plate_values.append([plate.plate_array, outliers_mask])
+        except Exception as e:
+            logger.warning(f"Error while parsing file {filename}: {e}")
+            failed_files[filename] = str(e)
     df = pd.DataFrame(plate_summaries)
     plate_values = np.asarray(plate_values)
-    return df, plate_values
+    return df, plate_values, failed_files
 
 
 def calculate_activation_inhibition_zscore(

--- a/dashboard/pages/components.py
+++ b/dashboard/pages/components.py
@@ -213,7 +213,7 @@ def make_file_list_component(
                                 className="col",
                                 children=html.Ul(
                                     children=[
-                                        html.Li(name.split(".")[0])
+                                        html.Li(name)
                                         for name in successfull_filenames[i::num_cols]
                                     ]
                                 ),
@@ -239,7 +239,7 @@ def make_file_list_component(
                                 className="col",
                                 children=html.Ul(
                                     children=[
-                                        html.Li(name.split(".")[0])
+                                        html.Li(name)
                                         for name in failed_filenames[i::num_cols]
                                     ]
                                 ),

--- a/dashboard/pages/screening/callbacks.py
+++ b/dashboard/pages/screening/callbacks.py
@@ -253,7 +253,11 @@ def on_export_plots_button_click(
         bmg_df, bmg_vals, n_rows, HEATMAP_PLOT_REPORT_COLS, free_format=True
     )
     fig.update_layout(
-        height=n_rows * HEATMAP_PLOT_REPORT_HEIGHT_PER_ROW, coloraxis_showscale=False
+        height=n_rows * HEATMAP_PLOT_REPORT_HEIGHT_PER_ROW,
+        coloraxis_showscale=False,
+    )
+    fig.update_annotations(
+        font_size=16,
     )
     as_html = fig.to_html()
     filename = f"screening_heatmaps_{datetime.now().strftime('%Y-%m-%dT%H_%M_%S')}.html"

--- a/dashboard/pages/screening/stages/s2_outliers_purging.py
+++ b/dashboard/pages/screening/stages/s2_outliers_purging.py
@@ -176,18 +176,34 @@ STATS_SECTION = html.Div(
                 ),
             ]
         ),
-        annotate_with_tooltip(
-            html.Div(
-                children=[
-                    dcc.Checklist(
-                        id="heatmap-outliers-checklist",
-                        options=["Show only with outliers"],
-                        inputClassName="me-2",
+        html.Div(
+            children=[
+                dcc.Loading(
+                    html.Button(
+                        id="heatmaps-export-btn",
+                        children=[
+                            "Export Plates Plots",
+                            dcc.Download(id="download-plates-heatmap"),
+                        ],
+                        className="btn btn-primary",
                     ),
-                ],
-            ),
-            SHOW_ONLY_WITH_OUTLIERS_DESC,
-            extra_style={"transform": "translateY(2px)"},
+                    type="circle",
+                ),
+                annotate_with_tooltip(
+                    html.Div(
+                        children=[
+                            dcc.Checklist(
+                                id="heatmap-outliers-checklist",
+                                options=["Show only with outliers"],
+                                inputClassName="me-2",
+                            ),
+                        ],
+                    ),
+                    SHOW_ONLY_WITH_OUTLIERS_DESC,
+                    extra_style={"transform": "translateY(2px)"},
+                ),
+            ],
+            className="d-flex flex-row gap-3 align-items-center",
         ),
     ],
 )

--- a/dashboard/pages/screening/stages/s2_outliers_purging.py
+++ b/dashboard/pages/screening/stages/s2_outliers_purging.py
@@ -131,7 +131,19 @@ STATS_SECTION = html.Div(
     className="d-flex flex-row justify-content-between align-items-center",
     children=[
         html.Div(
+            className="d-flex flex-row gap-3 align-items-center",
             children=[
+                dcc.Loading(
+                    html.Button(
+                        id="heatmaps-export-btn",
+                        children=[
+                            "Export Plates Plots",
+                            dcc.Download(id="download-plates-heatmap"),
+                        ],
+                        className="btn btn-primary",
+                    ),
+                    type="circle",
+                ),
                 html.Span(
                     className="mx-2",
                     children=[
@@ -174,21 +186,10 @@ STATS_SECTION = html.Div(
                         ),
                     ],
                 ),
-            ]
+            ],
         ),
         html.Div(
             children=[
-                dcc.Loading(
-                    html.Button(
-                        id="heatmaps-export-btn",
-                        children=[
-                            "Export Plates Plots",
-                            dcc.Download(id="download-plates-heatmap"),
-                        ],
-                        className="btn btn-primary",
-                    ),
-                    type="circle",
-                ),
                 annotate_with_tooltip(
                     html.Div(
                         children=[

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -175,7 +175,11 @@ def make_projection_plot(
 
 
 def visualize_multiple_plates(
-    df: pd.DataFrame, plate_array: np.ndarray, rows: int = 3, cols: int = 3
+    df: pd.DataFrame,
+    plate_array: np.ndarray,
+    rows: int = 3,
+    cols: int = 3,
+    free_format: bool = False,
 ) -> go.Figure:
     """
     Visualize plate values on subplots 3x3
@@ -184,14 +188,17 @@ def visualize_multiple_plates(
     :param plate_array: array with plate values
     :param rows: number of rows in plot grid
     :param cols: number of cols in plot grid
+    :param free_format: whether to use free format for export
     :return: plot with visualized plates
     """
+    extra_args = {}
+    if not free_format:
+        extra_args = {"horizontal_spacing": 0.01, "vertical_spacing": 0.05}
     fig = make_subplots(
         rows,
         cols,
-        horizontal_spacing=0.01,
-        vertical_spacing=0.05,
         subplot_titles=df.barcode.to_list(),
+        **extra_args,
     )
     ids = product(list(range(1, rows + 1)), list(range(1, cols + 1)))
     for i, p, plate in zip(range(1, rows * cols + 1), ids, plate_array):
@@ -206,18 +213,19 @@ def visualize_multiple_plates(
             p[1],
         )
 
-        fig.update_layout(
-            {
-                f"xaxis{i}": {"fixedrange": True, "showgrid": False},
-                f"yaxis{i}": {
-                    "fixedrange": True,
-                    "showgrid": False,
-                    "scaleanchor": f"x{i}",
-                    "autorange": "reversed",
-                },
-                "autosize": True,
-            }
-        )
+        if not free_format:
+            fig.update_layout(
+                {
+                    f"xaxis{i}": {"fixedrange": True, "showgrid": False},
+                    f"yaxis{i}": {
+                        "fixedrange": True,
+                        "showgrid": False,
+                        "scaleanchor": f"x{i}",
+                        "autorange": "reversed",
+                    },
+                    "autosize": True,
+                }
+            )
 
     fig.update_layout(
         coloraxis={"colorscale": "viridis"},

--- a/dashboard/visualization/plots.py
+++ b/dashboard/visualization/plots.py
@@ -191,9 +191,12 @@ def visualize_multiple_plates(
     :param free_format: whether to use free format for export
     :return: plot with visualized plates
     """
-    extra_args = {}
+    extra_args = {
+        "horizontal_spacing": 0.01,
+        "vertical_spacing": 0.02,
+    }
     if not free_format:
-        extra_args = {"horizontal_spacing": 0.01, "vertical_spacing": 0.05}
+        extra_args["vertical_spacing"] = 0.05
     fig = make_subplots(
         rows,
         cols,


### PR DESCRIPTION
Fixed bug that prevented client's bmg file from being uploaded (it had an empty newline).

To prevent any further issues, I added simple error handling - bad files will not be parsed and will be reported to the user alongside the message why they failed (example: failing data from confirmatory screening)
<img width="673" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/2bf7f85b-9cf8-4f6f-ae73-d0ce4c7f4d20">

Added new button that allows to download all heatmaps as a single file:
<img width="686" alt="image" src="https://github.com/zuzg/drug-screening/assets/72276326/b52ef4ea-a81c-4e15-8d9b-3c89741403a4">
